### PR TITLE
fix: explicitly load conf file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./data/${PRESET:?err}/core:/dash/data
     command:
       - dashd
+      - -conf=/dash/.dashcore/dash.conf
       - -datadir=/dash/data
       - -port=${CORE_P2P_PORT:?err}
       - -masternodeblsprivkey=${CORE_MASTERNODE_BLS_PRIV_KEY:?err}


### PR DESCRIPTION
Specifying options in the command causes dashd to start without loading the dash.conf file, even if it is in the default location.