### PR TITLE
fix: unavailable balance info during testnet registration

### DIFF
--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -62,7 +62,7 @@ class RegisterCommand extends BaseCommand {
             {
               title: 'Start Core',
               task: async (ctx) => {
-                ctx.coreService = await startCore(preset, { wallet: true });
+                ctx.coreService = await startCore(preset, { wallet: true, addressindex: true });
               },
             },
             {

--- a/src/core/startCoreFactory.js
+++ b/src/core/startCoreFactory.js
@@ -37,6 +37,10 @@ function startCoreFactory(
       coreCommand.push('--disablewallet=0');
     }
 
+    if (options.addressindex) {
+      coreCommand.push('--addressindex=1');
+    }
+
     const coreContainer = await dockerCompose.runService(
       preset,
       'core',


### PR DESCRIPTION
`mn register testnet [args]` failed at `Check funding address balance` with the error `No information available for address` when using a new funding privkey after the blockchain data had already been downloaded. This fix ensures it is always possible to check the balance of an address when registering a masternode.