### PR TITLE
fix: reset command fails for testnet preset

### DIFF
--- a/src/commands/reset.js
+++ b/src/commands/reset.js
@@ -31,6 +31,7 @@ class ResetCommand extends BaseCommand {
           new Listr([
             {
               title: 'Remove Tendermint data',
+              enabled: () => preset !== PRESETS.TESTNET,
               task: async () => {
                 if (await dockerCompose.isServiceRunning(preset)) {
                   throw new Error('You can\'t reset data while MN is running. Please stop it.');
@@ -50,6 +51,7 @@ class ResetCommand extends BaseCommand {
             },
             {
               title: 'Remove Drive data',
+              enabled: () => preset !== PRESETS.TESTNET,
               task: async () => dockerCompose.down(preset),
             },
           ])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/dashevo/mn-bootstrap/issues/53

## What was done?
<!--- Describe your changes in detail -->
Disabled reset Drive and Tendermint tasks for testnet preset.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by running `mn reset testnet`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
