### PR TITLE
fix: switch to dashpay org for sentinel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - -externalip=${CORE_EXTERNAL_IP:?err}
 
   sentinel:
-    image: strophy/sentinel
+    image: dashpay/sentinel
     restart: unless-stopped
     depends_on:
       - core


### PR DESCRIPTION
## Issue being fixed or feature implemented
This switches the sentinel image from my personal repo to the dashpay organizational repo, now that I have gained access.

## What was done?
Rebuilt image from organizational repos. The actual image content is identical.

## How Has This Been Tested?
Started a full node, verified sentinel started up properly, entered the running container and verified sentinel<-->core communication was working as expected.

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
