### PR TITLE
fix: using drive or dapi build image path option caused a fatal error

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -65,7 +65,7 @@ class StartCommand extends BaseCommand {
 
             const envFile = path.join(__dirname, '..', '..', `.env.${preset}`);
             const envRawData = await fs.readFile(envFile);
-            let { composeFile } = dotenv.parse(envRawData);
+            let { COMPOSE_FILE: composeFile } = dotenv.parse(envRawData);
 
             if (driveImageBuildPath) {
               composeFile = `${composeFile}:docker-compose.platform.build-drive.yml`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Using drive or dapi build image path option caused a fatal error

## What was done?
Fixed issue


## How Has This Been Tested?
Run bootstrap in different configs

## Breaking Changes
No


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
