### PR TITLE
fix!: rate limits disabled for evonet and enabled for local

### DIFF
--- a/configs/evonet/dapi/nginx/default.conf
+++ b/configs/evonet/dapi/nginx/default.conf
@@ -1,4 +1,4 @@
-# limit_req_zone $binary_remote_addr zone=protect_api:15m rate=120r/m;
+limit_req_zone $binary_remote_addr zone=protect_http_api:15m rate=120r/m;
 
 server {
     listen 80 default_server;

--- a/configs/evonet/dapi/nginx/grpc.conf
+++ b/configs/evonet/dapi/nginx/grpc.conf
@@ -10,7 +10,7 @@ map $upstream_trailer_grpc_status $grpc_status {
                                            # who generated it
 }
 
-limit_req_zone $binary_remote_addr zone=protect_api:15m rate=120r/m;
+limit_req_zone $binary_remote_addr zone=protect_http2_api:15m rate=120r/m;
 
 server {
     listen 50051 http2;

--- a/configs/local/dapi/nginx/default.conf
+++ b/configs/local/dapi/nginx/default.conf
@@ -1,5 +1,3 @@
-# limit_req_zone $binary_remote_addr zone=protect_api:15m rate=120r/m;
-
 server {
     listen 80 default_server;
 

--- a/configs/local/dapi/nginx/grpc.conf
+++ b/configs/local/dapi/nginx/grpc.conf
@@ -10,8 +10,6 @@ map $upstream_trailer_grpc_status $grpc_status {
                                            # who generated it
 }
 
-limit_req_zone $binary_remote_addr zone=protect_api:15m rate=120r/m;
-
 server {
     listen 50051 http2;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DAPI rate limits disabled for evonet and enabled for local for some reason

## What was done?
<!--- Describe your changes in detail -->
Disable rate limits for local and enable for evonet presets in DAPI Nginx configs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Evonet will limit requests for JSON RPC and gRPC Web

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
