### PR TITLE
feat: implement `update` option for `start` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ ARGUMENTS
 OPTIONS
   -f, --full-node                                  start as full node
   -p, --operator-private-key=operator-private-key  operator private key
+  -u, --update                                     pull updated Docker images
 ```
 
 To start a masternode for Evonet:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ARGUMENTS
 OPTIONS
   -f, --full-node                                  start as full node
   -p, --operator-private-key=operator-private-key  operator private key
-  -u, --update                                     pull updated Docker images
+  -u, --update                                     download updated services before start
 ```
 
 To start a masternode for Evonet:

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -39,7 +39,7 @@ class StartCommand extends BaseCommand {
   ) {
     const tasks = new Listr([
       {
-        title: 'Pull updated images',
+        title: 'Download updated services',
         enabled: () => isUpdate === true,
         task: async (ctx) => await dockerCompose.pull(preset),
       },

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -120,7 +120,7 @@ StartCommand.args = [{
 
 StartCommand.flags = {
   'full-node': flagTypes.boolean({ char: 'f', description: 'start as full node', default: false }),
-  'update': flagTypes.boolean({ char: 'u', description: 'pull updated Docker images', default: false }),
+  'update': flagTypes.boolean({ char: 'u', description: 'download updated services before start', default: false }),
   'operator-private-key': flagTypes.string({ char: 'p', description: 'operator private key', default: null }),
   'drive-image-build-path': flagTypes.string({ description: 'drive\'s docker image build path', default: null }),
   'dapi-image-build-path': flagTypes.string({ description: 'dapi\'s docker image build path', default: null }),

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -30,6 +30,7 @@ class StartCommand extends BaseCommand {
     },
     {
       'full-node': isFullNode,
+      'update': isUpdate,
       'operator-private-key': operatorPrivateKey,
       'drive-image-build-path': driveImageBuildPath,
       'dapi-image-build-path': dapiImageBuildPath,
@@ -37,6 +38,11 @@ class StartCommand extends BaseCommand {
     dockerCompose,
   ) {
     const tasks = new Listr([
+      {
+        title: 'Pull updated images',
+        enabled: () => isUpdate === true,
+        task: async (ctx) => await dockerCompose.pull(preset),
+      },
       {
         title: `Start ${isFullNode ? 'full node' : 'masternode'} with ${preset} preset`,
         task: async () => {
@@ -114,6 +120,7 @@ StartCommand.args = [{
 
 StartCommand.flags = {
   'full-node': flagTypes.boolean({ char: 'f', description: 'start as full node', default: false }),
+  'update': flagTypes.boolean({ char: 'u', description: 'pull updated Docker images', default: false }),
   'operator-private-key': flagTypes.string({ char: 'p', description: 'operator private key', default: null }),
   'drive-image-build-path': flagTypes.string({ description: 'drive\'s docker image build path', default: null }),
   'dapi-image-build-path': flagTypes.string({ description: 'dapi\'s docker image build path', default: null }),

--- a/src/docker/DockerCompose.js
+++ b/src/docker/DockerCompose.js
@@ -159,6 +159,27 @@ class DockerCompose {
   }
 
   /**
+   * Pull docker compose
+   *
+   * @param {string} preset
+   * @return {Promise<void>}
+   */
+  async pull(preset) {
+    await this.throwErrorIfNotInstalled();
+
+    const env = this.getPlaceholderEmptyEnvOptions();
+
+    try {
+      await dockerCompose.pullAll({
+        ...this.getOptions(preset, env),
+        commandOptions: ['-q'],
+      });
+    } catch (e) {
+      throw new DockerComposeError(e);
+    }
+  }
+
+  /**
    * @private
    * @return {Promise<void>}
    */


### PR DESCRIPTION
Implements #74:  pull option to update docker images before starting

## What was done?
Added `-u` flag to start command to pull image updates before proceeding with start.

## How Has This Been Tested?
I think I have implemented this properly, but I'm unsure how to test it. What use case does it fix? Are devs changing version numbers in the .env files before running the start command, wouldn't this force a pull already? Which images can I use for testing?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

