### PR TITLE
fix: missing `build` section for `tx_filter_stream_service` service

### DIFF
--- a/docker-compose.platform.build-dapi.yml
+++ b/docker-compose.platform.build-dapi.yml
@@ -3,8 +3,6 @@ version: '3.7'
 services:
   dapi_api:
     build: ${DAPI_IMAGE_BUILD_PATH:?err}
-    image: dapi:local
 
   dapi_tx_filter_stream:
-    # we don't need to build image here, we just use dapi:local image built in dapi_api
-    image: dapi:local
+    build: ${DAPI_IMAGE_BUILD_PATH:?err}

--- a/docker-compose.platform.build-dapi.yml
+++ b/docker-compose.platform.build-dapi.yml
@@ -3,6 +3,8 @@ version: '3.7'
 services:
   dapi_api:
     build: ${DAPI_IMAGE_BUILD_PATH:?err}
+    image: dapi:local
 
   dapi_tx_filter_stream:
     build: ${DAPI_IMAGE_BUILD_PATH:?err}
+    image: dapi:local

--- a/docker-compose.platform.build-drive.yml
+++ b/docker-compose.platform.build-drive.yml
@@ -3,3 +3,4 @@ version: '3.7'
 services:
   drive_abci:
     build: ${DRIVE_IMAGE_BUILD_PATH:?err}
+    image: drive:local

--- a/docker-compose.platform.build-drive.yml
+++ b/docker-compose.platform.build-drive.yml
@@ -3,4 +3,3 @@ version: '3.7'
 services:
   drive_abci:
     build: ${DRIVE_IMAGE_BUILD_PATH:?err}
-    image: drive:local


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Docker does not know about `dapi:local` and `drive:local` images upon first run

## What was done?
<!--- Describe your changes in detail -->
Use only `build` instructions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local dev env.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
