### PR TITLE
fix: missing env variables for `dapi-tx-filter-stream` service

### DIFF
--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -100,6 +100,8 @@ services:
       - DASHCORE_P2P_PORT=20001
       - DASHCORE_P2P_NETWORK=devnet
       - NETWORK=devnet
+      - TENDERMINT_RPC_HOST=drive_tendermint
+      - TENDERMINT_RPC_PORT=26657
     command: npm run tx-filter-stream
 
   dapi_envoy:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing missing env vars

## What was done?
<!--- Describe your changes in detail -->
Added `TENDERMINT_HOST` and `TENDERMINT_PORT` vars

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local dev env.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
