### PR TITLE
fix: bump evonet version

### DIFF
--- a/configs/evonet/core/dashd.conf
+++ b/configs/evonet/core/dashd.conf
@@ -1,6 +1,6 @@
 # general
 
-devnet=evonet-4
+devnet=evonet-5
 
 daemon=0  # leave this set to 0 for Docker
 logtimestamps=1


### PR DESCRIPTION
## Issue being fixed or feature implemented
Bumps evonet version to match the version currently deployed on the network. Resolves the following error on core startup:

`
2020-07-24 00:36:50 connected to wrong devnet. Reported version is /Dash Core:0.15.0(devnet=devnet-evonet-5)/, expected devnet name is devnet-evonet-4
`

## What was done?
Increment version number


## How Has This Been Tested?
Ran `mn start evonet <...>` and it worked


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
