### PR TITLE
fix: transaction filter stream doesn't work with gRPC-Web

### DIFF
--- a/configs/evonet/dapi/envoy/grpc.yaml
+++ b/configs/evonet/dapi/envoy/grpc.yaml
@@ -44,11 +44,10 @@ static_resources:
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    # win/mac hosts: Use address: host.docker.internal instead of address: localhost in the line below
     hosts: [{ socket_address: { address: dapi_api, port_value: 3005 }}]
   - name: tx_filter_stream
     connect_timeout: 0.25s
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    hosts: [{ socket_address: { address: dapi_api, port_value: 3006 }}]
+    hosts: [{ socket_address: { address: dapi_tx_filter_stream, port_value: 3006 }}]

--- a/configs/local/dapi/envoy/grpc.yaml
+++ b/configs/local/dapi/envoy/grpc.yaml
@@ -44,11 +44,10 @@ static_resources:
       type: logical_dns
       http2_protocol_options: {}
       lb_policy: round_robin
-      # win/mac hosts: Use address: host.docker.internal instead of address: localhost in the line below
       hosts: [{ socket_address: { address: dapi_api, port_value: 3005 }}]
     - name: tx_filter_stream
       connect_timeout: 0.25s
       type: logical_dns
       http2_protocol_options: {}
       lb_policy: round_robin
-      hosts: [{ socket_address: { address: dapi_api, port_value: 3006 }}]
+      hosts: [{ socket_address: { address: dapi_tx_filter_stream, port_value: 3006 }}]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Transaction filter stream doesn't work with gRPC-Web clients

## What was done?
<!--- Describe your changes in detail -->
Fixed wrong address for Transaction filter stream service in Envoy config

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
