### PR TITLE
fix: typo in dpns ownerId

### DIFF
--- a/src/config/systemConfigs/systemConfigs.js
+++ b/src/config/systemConfigs/systemConfigs.js
@@ -89,7 +89,7 @@ module.exports = {
     platform: {
       dpns: {
         contractId: 'FiBkhut4LFPMJqDWbZrxVeT6Mr6LsH3mTNTSSHJY2ape',
-        ownerId: 'UZ9jAodWiFxRg82HuA1Lf3mTh4fTGSiughxqkZX5kUA',
+        ownerId: '6UZ9jAodWiFxRg82HuA1Lf3mTh4fTGSiughxqkZX5kUA',
       },
     },
     network: NETWORKS.EVONET,


### PR DESCRIPTION
Fixes a typo introduced in #119 

## Issue being fixed or feature implemented
This typo was prevent abci from syncing and causing tendermint to crash


## What was done?
- [x] Change dpns ownerId to correct value


## How Has This Been Tested?
- [x] Tested previously failing evonet sync and verified it works


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
