### PR TITLE
fix: gRPC buffer size settings in NGINX was too small

### DIFF
--- a/configs/evonet/dapi/nginx/grpc.conf
+++ b/configs/evonet/dapi/nginx/grpc.conf
@@ -20,14 +20,17 @@ server {
 
     location /org.dash.platform.dapi.v0.Core/subscribeToTransactionsWithProofs {
         grpc_pass grpc://dapi_tx_filter_stream:3006;
+        grpc_buffer_size 128k;
     }
 
     location /org.dash.platform.dapi.v0.Core {
         grpc_pass grpc://dapi_api:3005;
+        grpc_buffer_size 128k;
     }
 
     location /org.dash.platform.dapi.v0.Platform {
         grpc_pass grpc://dapi_api:3005;
+        grpc_buffer_size 128k;
     }
 
     location /grpc.health.v1.Health {

--- a/configs/local/dapi/nginx/grpc.conf
+++ b/configs/local/dapi/nginx/grpc.conf
@@ -17,14 +17,17 @@ server {
 
     location /org.dash.platform.dapi.v0.Core/subscribeToTransactionsWithProofs {
         grpc_pass grpc://dapi_tx_filter_stream:3006;
+        grpc_buffer_size 128k;
     }
 
     location /org.dash.platform.dapi.v0.Core {
         grpc_pass grpc://dapi_api:3005;
+        grpc_buffer_size 128k;
     }
 
     location /org.dash.platform.dapi.v0.Platform {
         grpc_pass grpc://dapi_api:3005;
+        grpc_buffer_size 128k;
     }
 
     location /grpc.health.v1.Health {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`grpc_pass` buffer size setting was to small resulting in `upstream sent too big header while reading response header from upstream` error

## What was done?
<!--- Describe your changes in detail -->
Increased buffer size to 128k

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local dev env.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
