### PR TITLE
feat: new option for block mining with local config

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.2",
     "lodash.set": "^4.3.2",
-    "ms": "^2.1.2",
     "node-graceful": "^3.0.0",
     "pretty-bytes": "^5.3.0",
     "pretty-ms": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.2",
     "lodash.set": "^4.3.2",
+    "ms": "^2.1.2",
     "node-graceful": "^3.0.0",
     "pretty-bytes": "^5.3.0",
     "pretty-ms": "^7.0.0",

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -35,17 +35,19 @@ class StartCommand extends BaseCommand {
   ) {
     let blockTimeMs;
 
-    const mineBlocks = config.get('core.miner.enable');
+    const isMinerEnabled = config.get('core.miner.enable');
 
-    if (mineBlocks !== false) {
+    if (isMinerEnabled === true) {
       if (config.get('network') !== NETWORKS.LOCAL) {
-        this.error(`mine-blocks option supposed to work only with local network. Your network is ${config.get('network')}`, { exit: true });
+        this.error(`'core.miner.interval' option supposed to work only with local network. Your network is ${config.get('network')}`, { exit: true });
       }
 
       const mineInterval = config.get('core.miner.interval');
+      
       blockTimeMs = ms(mineInterval);
+
       if (blockTimeMs === undefined || blockTimeMs < 0) {
-        this.error(`Invalid mine-blocks value ${mineInterval}`, { exit: true });
+        this.error(`Invalid 'core.miner.interval' value '${mineInterval}'`, { exit: true });
       }
     }
 
@@ -65,7 +67,7 @@ class StartCommand extends BaseCommand {
         },
         {
           title: 'Start a miner',
-          enabled: () => mineBlocks !== false,
+          enabled: () => isMinerEnabled === true,
           task: async () => {
             let minerAddress = config.get('core.miner.address');
 

--- a/src/config/configJsonSchema.js
+++ b/src/config/configJsonSchema.js
@@ -81,6 +81,7 @@ module.exports = {
             },
             interval: {
               type: 'string',
+              pattern: '^[0-9]+(.[0-9]+)?(m|s|h)?$',
             },
             address: {
               type: ['string', 'null'],

--- a/src/config/configJsonSchema.js
+++ b/src/config/configJsonSchema.js
@@ -81,7 +81,7 @@ module.exports = {
             },
             interval: {
               type: 'string',
-              pattern: '^[0-9]+(.[0-9]+)?(m|s|h)?$',
+              pattern: '^[0-9]+(.[0-9]+)?(m|s|h)$',
             },
             address: {
               type: ['string', 'null'],

--- a/src/config/configJsonSchema.js
+++ b/src/config/configJsonSchema.js
@@ -91,7 +91,7 @@ module.exports = {
           additionalProperties: false,
         },
       },
-      required: ['docker', 'version', 'p2p', 'masternode'],
+      required: ['docker', 'version', 'p2p', 'masternode', 'miner'],
       additionalProperties: false,
     },
     platform: {

--- a/src/config/configJsonSchema.js
+++ b/src/config/configJsonSchema.js
@@ -73,6 +73,22 @@ module.exports = {
           required: ['operator'],
           additionalProperties: false,
         },
+        miner: {
+          type: 'object',
+          properties: {
+            enable: {
+              type: 'boolean',
+            },
+            interval: {
+              type: 'string',
+            },
+            address: {
+              type: ['string', 'null'],
+            },
+          },
+          required: ['enable', 'interval', 'address'],
+          additionalProperties: false,
+        },
       },
       required: ['docker', 'version', 'p2p', 'masternode'],
       additionalProperties: false,

--- a/src/config/systemConfigs/systemConfigs.js
+++ b/src/config/systemConfigs/systemConfigs.js
@@ -83,6 +83,13 @@ module.exports = {
     description: 'standalone node for local development',
     externalIp: '127.0.0.1',
     network: NETWORKS.LOCAL,
+    core: {
+      miner: {
+        enable: false,
+        interval: '2.5m',
+        address: null,
+      },
+    },
   }),
   evonet: lodashMerge({}, baseConfig, {
     description: 'node with Evonet configuration',

--- a/src/config/systemConfigs/systemConfigs.js
+++ b/src/config/systemConfigs/systemConfigs.js
@@ -17,6 +17,11 @@ const baseConfig = {
         privateKey: null,
       },
     },
+    miner: {
+      enable: false,
+      interval: '2.5m',
+      address: null,
+    },
   },
   platform: {
     dapi: {
@@ -83,13 +88,6 @@ module.exports = {
     description: 'standalone node for local development',
     externalIp: '127.0.0.1',
     network: NETWORKS.LOCAL,
-    core: {
-      miner: {
-        enable: false,
-        interval: '2.5m',
-        address: null,
-      },
-    },
   }),
   evonet: lodashMerge({}, baseConfig, {
     description: 'node with Evonet configuration',

--- a/src/docker/DockerCompose.js
+++ b/src/docker/DockerCompose.js
@@ -143,9 +143,10 @@ class DockerCompose {
    * @param {Object} envs
    * @param {string} serviceName
    * @param {string} command
+   * @param {string[]} [commandOptions]
    * @return {Promise<object>}
    */
-  async execCommand(envs, serviceName, command) {
+  async execCommand(envs, serviceName, command, commandOptions = []) {
     await this.throwErrorIfNotInstalled();
 
     if (!(await this.isServiceRunning(envs, serviceName))) {
@@ -154,11 +155,16 @@ class DockerCompose {
 
     let commandOutput;
 
+    const options = {
+      ...this.getOptions(envs),
+      commandOptions,
+    };
+
     try {
       commandOutput = await dockerCompose.exec(
         serviceName,
         command,
-        this.getOptions(envs),
+        options,
       );
     } catch (e) {
       throw new DockerComposeError(e);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to avoid mining manually during tests and development with a local  node, we should introduce an option for the node start command  that will start miner script if present.

## What was done?
<!--- Describe your changes in detail -->
Added a new option `mine-blocks` for the `start` command

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
