### PR TITLE
fix: can't generate genesis config for local

### DIFF
--- a/configs/local/drive/tendermint/config.toml
+++ b/configs/local/drive/tendermint/config.toml
@@ -47,7 +47,7 @@ log_format = "plain"
 ##### additional base config options #####
 
 # Path to the JSON file containing the initial validator set and other meta data
-genesis_file = "config/genesis.json"
+genesis_file = "data/genesis.json"
 
 # Path to the JSON file containing the private key to use as a validator in the consensus protocol
 priv_validator_key_file = "data/priv_validator_key.json"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For the local network, we do not provide `genesis.json` which should be dynamically generated by `tendermint int` command from docker compose config. So we need to move this file to tendermint data volume to make it writeable for tendermint.

## What was done?
<!--- Describe your changes in detail -->
`genesis.json` is set to writable `data` dir.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With running `mn setup-for-local-development`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
