### PR TITLE
fix: set config bind mount read-only

### DIFF
--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -44,7 +44,7 @@ services:
     ports:
       - 26656:26656 # P2P
     volumes:
-      - ./configs/${NETWORK:?err}/drive/tendermint:/tendermint/config
+      - ./configs/${NETWORK:?err}/drive/tendermint:/tendermint/config:ro
       - drive_tendermint_homedir:/tendermint
     entrypoint: sh -c "/usr/bin/tendermint init && /usr/bin/tendermint node"
 


### PR DESCRIPTION
Set `config` dir read only to prevent accidentally writing mutable state.

## Issue being fixed or feature implemented
It is not possible to bind-mount the config files directly in `docker-compose.platform.yml` because not all configs provide a `genesis.json` file. Also the `~/config` directory does not exist in the Docker image, which would result in creation of the config dir as root. However, it is still important not to write mutable data to this directory. This PR ensures that the config dir is read-only.

## What was done?
Add `:ro` flag to bind mount instruction.


## How Has This Been Tested?
Started masternode and attempted to reproduce the bug fixed in #140 . Masternode startup fails with logs showing the error `ERROR: open /tendermint/config/genesis.json: read-only file system`


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
