### PR TITLE
fix: services.core.ports contains an invalid type

### DIFF
--- a/src/commands/config/envs.js
+++ b/src/commands/config/envs.js
@@ -22,7 +22,7 @@ class ConfigEnvsCommand extends BaseCommand {
     let envOutput = '';
 
     for (const [key, value] of Object.entries(config.toEnvs())) {
-      envOutput += `${key}="${value}"\n`;
+      envOutput += `${key}=${value}\n`;
     }
 
     if (outputFile !== null) {


### PR DESCRIPTION
Removes quotes from generated .env file, since these are not handled by docker-compose.

## Issue being fixed or feature implemented
Trying to start a node with `mn config:envs -o .env && docker-compose up` fails with various errors as follows:
```
services.core.ports contains an invalid type, it should be a number, or an object
ERROR: .FileNotFoundError: [Errno 2] No such file or directory: './"docker-compose.yml"'
```

According to the [env file spec](https://docs.docker.com/compose/env-file/):
- There is no special handling of quotation marks. This means that **they are part of the VAL.**

## What was done?
Remove quotes from generated output.

## How Has This Been Tested?
`mn config:envs -o .env && docker-compose up`
  --> no errors, services start as expected

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
