### PR TITLE
feat: restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Distribution package for Dash Masternode installation
   - [Configure node](#configure-node)
   - [Start node](#start-node)
   - [Stop node](#stop-node)
+  - [Restart node](#restard-node)
   - [Register masternode](#register-masternode)
   - [Reset data](#reset-data)
   - [Development](#development)
@@ -119,6 +120,27 @@ OPTIONS
 To stop a node:
 ```bash
 $ mn stop
+```
+
+### Restart node
+
+The `restart` command is used to restart a node with the default or specified config.
+
+```
+USAGE
+  $ mn restart
+
+OPTIONS
+  -f, --full-node                                  start as full node
+  -u, --update                                     download updated services before start
+  --config=config                                  configuration name to use
+  --dapi-image-build-path=dapi-image-build-path    dapi's docker image build path
+  --drive-image-build-path=drive-image-build-path  drive's docker image build path
+```
+
+To update services and restart a masternode:
+```bash
+$ mn restart -u
 ```
 
 ### Register masternode

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Distribution package for Dash Masternode installation
   - [Restart node](#restard-node)
   - [Register masternode](#register-masternode)
   - [Reset data](#reset-data)
+  - [Full node](#full-node)
   - [Development](#development)
   - [Docker Compose](#docker-compose)
 - [Contributing](#contributing)

--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ To show the host status:
 $ mn status:host
 ```
 
+### Full node
+
+It is also possible to start a full node instead of a masternode. Modify the config setting as follows:
+
+```bash
+mn config:set core.masternode.enable false
+```
+
 ### Development
 
 When developing on a standalone node (a config specifying the `local` network), `setup-for-local-development` can be used to generate some dash, register a masternode and populate the node with the data required for local development.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ The `start` command is used to start a node with the default or specified config
 USAGE
   $ mn start
 OPTIONS
-  -f, --full-node                                  start as full node
   -u, --update                                     download updated services before start
   --config=config                                  configuration name to use
   --dapi-image-build-path=dapi-image-build-path    dapi's docker image build path
@@ -99,11 +98,6 @@ OPTIONS
 To start a masternode:
 ```bash
 $ mn start
-```
-
-To start a full node:
-```bash
-$ mn start -f
 ```
 
 ### Stop node
@@ -131,7 +125,6 @@ USAGE
   $ mn restart
 
 OPTIONS
-  -f, --full-node                                  start as full node
   -u, --update                                     download updated services before start
   --config=config                                  configuration name to use
   --dapi-image-build-path=dapi-image-build-path    dapi's docker image build path

--- a/src/commands/restart.js
+++ b/src/commands/restart.js
@@ -1,0 +1,82 @@
+const { Listr } = require('listr2');
+
+const { flags: flagTypes } = require('@oclif/command');
+
+const BaseCommand = require('../oclif/command/BaseCommand');
+
+const MuteOneLineError = require('../oclif/errors/MuteOneLineError');
+
+class RestartCommand extends BaseCommand {
+  /**
+   * @param {Object} args
+   * @param {Object} flags
+   * @param {DockerCompose} dockerCompose
+   * @param {startNodeTask} startNodeTask
+   * @param {Config} config
+   * @return {Promise<void>}
+   */
+  async runWithDependencies(
+    args,
+    {
+      'full-node': isFullNode,
+      update: isUpdate,
+      'drive-image-build-path': driveImageBuildPath,
+      'dapi-image-build-path': dapiImageBuildPath,
+    },
+    dockerCompose,
+    startNodeTask,
+    config,
+  ) {
+    const isMinerEnabled = config.get('core.miner.enable');
+
+    const tasks = new Listr(
+      [
+        {
+          title: 'Stop node',
+          task: async () => dockerCompose.stop(config.toEnvs()),
+        },
+        {
+          title: `Start ${isFullNode ? 'full node' : 'masternode'}`,
+          task: () => startNodeTask(
+            config,
+            {
+              isFullNode,
+              driveImageBuildPath,
+              dapiImageBuildPath,
+              isUpdate,
+              isMinerEnabled,
+            },
+          ),
+        },
+      ],
+      {
+        rendererOptions: {
+          clearOutput: false,
+          collapse: false,
+          showSubtasks: true,
+        },
+      },
+    );
+
+    try {
+      await tasks.run();
+    } catch (e) {
+      throw new MuteOneLineError(e);
+    }
+  }
+}
+
+RestartCommand.description = `Restart masternode
+...
+Restart masternode with specific preset
+`;
+
+RestartCommand.flags = {
+  ...BaseCommand.flags,
+  'full-node': flagTypes.boolean({ char: 'f', description: 'start as full node', default: false }),
+  update: flagTypes.boolean({ char: 'u', description: 'download updated services before start', default: false }),
+  'drive-image-build-path': flagTypes.string({ description: 'drive\'s docker image build path', default: null }),
+  'dapi-image-build-path': flagTypes.string({ description: 'dapi\'s docker image build path', default: null }),
+};
+
+module.exports = RestartCommand;

--- a/src/commands/restart.js
+++ b/src/commands/restart.js
@@ -18,7 +18,6 @@ class RestartCommand extends BaseCommand {
   async runWithDependencies(
     args,
     {
-      'full-node': isFullNode,
       update: isUpdate,
       'drive-image-build-path': driveImageBuildPath,
       'dapi-image-build-path': dapiImageBuildPath,
@@ -28,6 +27,7 @@ class RestartCommand extends BaseCommand {
     config,
   ) {
     const isMinerEnabled = config.get('core.miner.enable');
+    const isMasternode = config.get('core.masternode.enable');
 
     const tasks = new Listr(
       [
@@ -36,11 +36,11 @@ class RestartCommand extends BaseCommand {
           task: async () => dockerCompose.stop(config.toEnvs()),
         },
         {
-          title: `Start ${isFullNode ? 'full node' : 'masternode'}`,
+          title: `Start ${isMasternode ? 'masternode' : 'full node'}`,
           task: () => startNodeTask(
             config,
             {
-              isFullNode,
+              isMasternode,
               driveImageBuildPath,
               dapiImageBuildPath,
               isUpdate,
@@ -73,7 +73,6 @@ Restart masternode with specific preset
 
 RestartCommand.flags = {
   ...BaseCommand.flags,
-  'full-node': flagTypes.boolean({ char: 'f', description: 'start as full node', default: false }),
   update: flagTypes.boolean({ char: 'u', description: 'download updated services before start', default: false }),
   'drive-image-build-path': flagTypes.string({ description: 'drive\'s docker image build path', default: null }),
   'dapi-image-build-path': flagTypes.string({ description: 'dapi\'s docker image build path', default: null }),

--- a/src/commands/restart.js
+++ b/src/commands/restart.js
@@ -26,7 +26,6 @@ class RestartCommand extends BaseCommand {
     startNodeTask,
     config,
   ) {
-    const isMinerEnabled = config.get('core.miner.enable');
     const isMasternode = config.get('core.masternode.enable');
 
     const tasks = new Listr(
@@ -40,11 +39,9 @@ class RestartCommand extends BaseCommand {
           task: () => startNodeTask(
             config,
             {
-              isMasternode,
               driveImageBuildPath,
               dapiImageBuildPath,
               isUpdate,
-              isMinerEnabled,
             },
           ),
         },

--- a/src/commands/setup-for-local-development.js
+++ b/src/commands/setup-for-local-development.js
@@ -61,7 +61,7 @@ class SetupForLocalDevelopmentCommand extends BaseCommand {
                   driveImageBuildPath: ctx.driveImageBuildPath,
                   dapiImageBuildPath: ctx.dapiImageBuildPath,
                   isUpdate,
-                  isMinerEnabled:true,
+                  isMinerEnabled: true,
                 },
               ),
             },

--- a/src/commands/setup-for-local-development.js
+++ b/src/commands/setup-for-local-development.js
@@ -54,10 +54,6 @@ class SetupForLocalDevelopmentCommand extends BaseCommand {
               task: () => registerMasternodeTask(config),
             },
             {
-              title: 'Enable miner',
-              task: () => config.set('core.miner.enable', true),
-            },
-            {
               title: 'Start masternode',
               task: async (ctx) => startNodeTask(
                 config,
@@ -65,6 +61,7 @@ class SetupForLocalDevelopmentCommand extends BaseCommand {
                   driveImageBuildPath: ctx.driveImageBuildPath,
                   dapiImageBuildPath: ctx.dapiImageBuildPath,
                   isUpdate,
+                  isMinerEnabled:true,
                 },
               ),
             },

--- a/src/commands/setup-for-local-development.js
+++ b/src/commands/setup-for-local-development.js
@@ -54,6 +54,10 @@ class SetupForLocalDevelopmentCommand extends BaseCommand {
               task: () => registerMasternodeTask(config),
             },
             {
+              title: 'Enable miner',
+              task: () => config.set('core.miner.enable', true),
+            },
+            {
               title: 'Start masternode',
               task: async (ctx) => startNodeTask(
                 config,
@@ -61,7 +65,6 @@ class SetupForLocalDevelopmentCommand extends BaseCommand {
                   driveImageBuildPath: ctx.driveImageBuildPath,
                   dapiImageBuildPath: ctx.dapiImageBuildPath,
                   isUpdate,
-                  isMinerEnabled: true,
                 },
               ),
             },

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -26,7 +26,6 @@ class StartCommand extends BaseCommand {
     startNodeTask,
     config,
   ) {
-    const isMinerEnabled = config.get('core.miner.enable');
     const isMasternode = config.get('core.masternode.enable');
 
     const tasks = new Listr(
@@ -36,11 +35,9 @@ class StartCommand extends BaseCommand {
           task: () => startNodeTask(
             config,
             {
-              isMasternode,
               driveImageBuildPath,
               dapiImageBuildPath,
               isUpdate,
-              isMinerEnabled,
             },
           ),
         },

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -18,7 +18,6 @@ class StartCommand extends BaseCommand {
   async runWithDependencies(
     args,
     {
-      'full-node': isFullNode,
       update: isUpdate,
       'drive-image-build-path': driveImageBuildPath,
       'dapi-image-build-path': dapiImageBuildPath,
@@ -28,15 +27,16 @@ class StartCommand extends BaseCommand {
     config,
   ) {
     const isMinerEnabled = config.get('core.miner.enable');
+    const isMasternode = config.get('core.masternode.enable');
 
     const tasks = new Listr(
       [
         {
-          title: `Start ${isFullNode ? 'full node' : 'masternode'}`,
+          title: `Start ${isMasternode ? 'masternode' : 'full node'}`,
           task: () => startNodeTask(
             config,
             {
-              isFullNode,
+              isMasternode,
               driveImageBuildPath,
               dapiImageBuildPath,
               isUpdate,
@@ -69,7 +69,6 @@ Start masternode with specific preset
 
 StartCommand.flags = {
   ...BaseCommand.flags,
-  'full-node': flagTypes.boolean({ char: 'f', description: 'start as full node', default: false }),
   update: flagTypes.boolean({ char: 'u', description: 'download updated services before start', default: false }),
   'drive-image-build-path': flagTypes.string({ description: 'drive\'s docker image build path', default: null }),
   'dapi-image-build-path': flagTypes.string({ description: 'dapi\'s docker image build path', default: null }),

--- a/src/config/configJsonSchema.js
+++ b/src/config/configJsonSchema.js
@@ -46,6 +46,9 @@ module.exports = {
         masternode: {
           type: 'object',
           properties: {
+            enable: {
+              type: 'boolean',
+            },
             operator: {
               type: 'object',
               properties: {
@@ -57,7 +60,7 @@ module.exports = {
               additionalProperties: false,
             },
           },
-          required: ['operator'],
+          required: ['enable', 'operator'],
           additionalProperties: false,
         },
         miner: {

--- a/src/config/systemConfigs/systemConfigs.js
+++ b/src/config/systemConfigs/systemConfigs.js
@@ -12,6 +12,7 @@ const baseConfig = {
       port: 20001,
     },
     masternode: {
+      enable: true,
       operator: {
         privateKey: null,
       },

--- a/src/listr/tasks/startNodeTaskFactory.js
+++ b/src/listr/tasks/startNodeTaskFactory.js
@@ -26,15 +26,15 @@ function startNodeTaskFactory(dockerCompose) {
   function startNodeTask(
     config,
     {
-      isMasternode,
       driveImageBuildPath = undefined,
       dapiImageBuildPath = undefined,
       isUpdate = undefined,
-      isMinerEnabled = undefined,
     },
   ) {
     // Check external IP is set
     config.get('externalIp', true);
+    const isMinerEnabled = config.get('core.miner.enable');
+    const isMasternode = config.get('core.masternode.enable');
 
     if (isMinerEnabled === true && config.get('network') !== NETWORKS.LOCAL) {
       this.error(`'core.miner.enabled' option supposed to work only with local network. Your network is ${config.get('network')}`, { exit: true });

--- a/src/listr/tasks/startNodeTaskFactory.js
+++ b/src/listr/tasks/startNodeTaskFactory.js
@@ -29,12 +29,15 @@ function startNodeTaskFactory(dockerCompose) {
       driveImageBuildPath = undefined,
       dapiImageBuildPath = undefined,
       isUpdate = undefined,
+      isMinerEnabled = undefined,
     },
   ) {
     // Check external IP is set
     config.get('externalIp', true);
-    
-    const isMinerEnabled = config.get('core.miner.enable');
+
+    if (isMinerEnabled === undefined) {
+      isMinerEnabled = config.get('core.miner.enable');
+    }
 
     if (isMinerEnabled === true && config.get('network') !== NETWORKS.LOCAL) {
       throw new Error(`'core.miner.enabled' option only works with local network. Your network is ${config.get('network')}.`, { exit: true });

--- a/src/listr/tasks/startNodeTaskFactory.js
+++ b/src/listr/tasks/startNodeTaskFactory.js
@@ -47,6 +47,14 @@ function startNodeTaskFactory(dockerCompose) {
         task: async () => dockerCompose.pull(config.toEnvs()),
       },
       {
+        title: 'Check for running services',
+        task: async () => {
+          if (await dockerCompose.isServiceRunning(config.toEnvs())) {
+            this.error(`Please ensure all services are stopped before starting`, { exit: true });
+          }
+        },
+      },
+      {
         title: 'Start services',
         task: async () => {
           if (isMasternode) {

--- a/src/listr/tasks/startNodeTaskFactory.js
+++ b/src/listr/tasks/startNodeTaskFactory.js
@@ -33,8 +33,8 @@ function startNodeTaskFactory(dockerCompose) {
   ) {
     // Check external IP is set
     config.get('externalIp', true);
+    
     const isMinerEnabled = config.get('core.miner.enable');
-    const isMasternode = config.get('core.masternode.enable');
 
     if (isMinerEnabled === true && config.get('network') !== NETWORKS.LOCAL) {
       this.error(`'core.miner.enabled' option supposed to work only with local network. Your network is ${config.get('network')}`, { exit: true });
@@ -57,6 +57,7 @@ function startNodeTaskFactory(dockerCompose) {
       {
         title: 'Start services',
         task: async () => {
+          const isMasternode = config.get('core.masternode.enable');
           if (isMasternode) {
             // Check operatorPrivateKey is set
             config.get('core.masternode.operator.privateKey', true);

--- a/src/listr/tasks/startNodeTaskFactory.js
+++ b/src/listr/tasks/startNodeTaskFactory.js
@@ -40,7 +40,7 @@ function startNodeTaskFactory(dockerCompose) {
     }
 
     if (isMinerEnabled === true && config.get('network') !== NETWORKS.LOCAL) {
-      throw new Error(`'core.miner.enabled' option only works with local network. Your network is ${config.get('network')}.`, { exit: true });
+      throw new Error(`'core.miner.enabled' option only works with local network. Your network is ${config.get('network')}.`);
     }
 
     return new Listr([
@@ -53,7 +53,7 @@ function startNodeTaskFactory(dockerCompose) {
         title: 'Check node is not started',
         task: async () => {
           if (await dockerCompose.isServiceRunning(config.toEnvs())) {
-            throw new Error(`Running services detected. Please ensure all services are stopped for this config before starting`, { exit: true });
+            throw new Error(`Running services detected. Please ensure all services are stopped for this config before starting`);
           }
         },
       },
@@ -70,7 +70,7 @@ function startNodeTaskFactory(dockerCompose) {
 
           if (driveImageBuildPath || dapiImageBuildPath) {
             if (config.get('network') === NETWORKS.TESTNET) {
-              throw new Error('You can\'t use drive-image-build-path and dapi-image-build-path options with testnet network', { exit: true });
+              throw new Error('You can\'t use drive-image-build-path and dapi-image-build-path options with testnet network');
             }
 
             if (driveImageBuildPath) {

--- a/src/listr/tasks/startNodeTaskFactory.js
+++ b/src/listr/tasks/startNodeTaskFactory.js
@@ -37,7 +37,7 @@ function startNodeTaskFactory(dockerCompose) {
     const isMinerEnabled = config.get('core.miner.enable');
 
     if (isMinerEnabled === true && config.get('network') !== NETWORKS.LOCAL) {
-      this.error(`'core.miner.enabled' option supposed to work only with local network. Your network is ${config.get('network')}`, { exit: true });
+      throw new Error(`'core.miner.enabled' option only works with local network. Your network is ${config.get('network')}.`, { exit: true });
     }
 
     return new Listr([
@@ -47,10 +47,10 @@ function startNodeTaskFactory(dockerCompose) {
         task: async () => dockerCompose.pull(config.toEnvs()),
       },
       {
-        title: 'Check for running services',
+        title: 'Check node is not started',
         task: async () => {
           if (await dockerCompose.isServiceRunning(config.toEnvs())) {
-            this.error(`Please ensure all services are stopped before starting`, { exit: true });
+            throw new Error(`Running services detected. Please ensure all services are stopped for this config before starting`, { exit: true });
           }
         },
       },
@@ -67,7 +67,7 @@ function startNodeTaskFactory(dockerCompose) {
 
           if (driveImageBuildPath || dapiImageBuildPath) {
             if (config.get('network') === NETWORKS.TESTNET) {
-              this.error('You can\'t use drive-image-build-path and dapi-image-build-path options with testnet network', { exit: true });
+              throw new Error('You can\'t use drive-image-build-path and dapi-image-build-path options with testnet network', { exit: true });
             }
 
             if (driveImageBuildPath) {

--- a/src/listr/tasks/startNodeTaskFactory.js
+++ b/src/listr/tasks/startNodeTaskFactory.js
@@ -16,7 +16,7 @@ function startNodeTaskFactory(dockerCompose) {
    * @typedef {startNodeTask}
    * @param {Config} config
    * @param {Object} options
-   * @param {boolean} [options.isFullNode]
+   * @param {boolean} [options.isMasternode]
    * @param {string} [options.driveImageBuildPath]
    * @param {string} [options.dapiImageBuildPath]
    * @param {boolean} [options.isUpdate]
@@ -26,7 +26,7 @@ function startNodeTaskFactory(dockerCompose) {
   function startNodeTask(
     config,
     {
-      isFullNode,
+      isMasternode,
       driveImageBuildPath = undefined,
       dapiImageBuildPath = undefined,
       isUpdate = undefined,
@@ -49,7 +49,7 @@ function startNodeTaskFactory(dockerCompose) {
       {
         title: 'Start services',
         task: async () => {
-          if (!isFullNode) {
+          if (isMasternode) {
             // Check operatorPrivateKey is set
             config.get('core.masternode.operator.privateKey', true);
           }


### PR DESCRIPTION
This PR implements the `restart` command described in #68 


## Issue being fixed or feature implemented
Now that the config command was implemented in #119, the config state is stored on disk. This allows us to restart a node with a single command, running updated code or config on restart.

## What was done?
My approach here was just to combine the stop and start commands in a single new command. Oclif allows you to [call commands programmatically](https://oclif.io/docs/running_programmatically), but I'm not sure if this is a good idea here, given we would just be passing the same arguments around anyway. 


## How Has This Been Tested?
- [x] Tested restarting nodes with different confs
- [x] Tested restarting after a config change was made to the running node


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
