### PR TITLE
fix: use conf sections in dash.conf

### DIFF
--- a/configs/evonet/core/dashd.conf
+++ b/configs/evonet/core/dashd.conf
@@ -19,7 +19,6 @@ zmqpubhashblock=tcp://0.0.0.0:29998
 
 # JSONRPC
 server=1
-rpcport=20002
 rpcuser=dashrpc
 rpcpassword=password
 
@@ -33,11 +32,14 @@ rpcthreads=16
 
 # external network
 listen=1
-bind=0.0.0.0
 dnsseed=0
 allowprivatenet=0
 
 printtoconsole=1
+
+[devnet]
+bind=0.0.0.0
+rpcport=20002
 
 addnode=seed-1.evonet.networks.dash.org:20001
 addnode=seed-2.evonet.networks.dash.org:20001

--- a/configs/local/core/dashd.conf
+++ b/configs/local/core/dashd.conf
@@ -20,7 +20,6 @@ zmqpubhashblock=tcp://0.0.0.0:29998
 
 # JSONRPC
 server=1
-rpcport=20002
 rpcuser=dashrpc
 rpcpassword=password
 
@@ -34,8 +33,11 @@ rpcthreads=16
 
 # external network
 listen=1
-bind=0.0.0.0
 dnsseed=0
 allowprivatenet=0
 
 printtoconsole=1
+
+[regtest]
+bind=0.0.0.0
+rpcport=20002


### PR DESCRIPTION
This PR is a fix to support new behaviour in Dash 0.16, which includes a [backport](https://github.com/dashpay/dash/commit/b0dc2ab3c1) of [bitcoin#11862](https://github.com/bitcoin/bitcoin/pull/11862) which breaks certain conf statements if they are not in the correct section.

## Issue being fixed or feature implemented
This fixes the following error:
```
2020-10-08 04:03:21 Dash Core version v0.16.0.1
2020-10-08 04:03:21 InitParameterInteraction: parameter interaction: -externalip set -> setting -discover=0
2020-10-08 04:03:21 InitParameterInteraction: parameter interaction: -whitelistforcerelay=1 -> setting -whitelistrelay=1
2020-10-08 04:03:21 InitParameterInteraction: parameter interaction: additional indexes -> setting -checklevel=4
2020-10-08 04:03:21 Warning: Config setting for -addnode only applied on devnet network when in [devnet] section.
2020-10-08 04:03:21 Warning: Config setting for -bind only applied on devnet network when in [devnet] section.
2020-10-08 04:03:21 Warning: Config setting for -rpcport only applied on devnet network when in [devnet] section.
2020-10-08 04:03:21 Error: -rpcport must be specified when -devnet and -server are specified
Error: -rpcport must be specified when -devnet and -server are specified
```


## What was done?
Moved necessary conf arguments to network-specific sections


## How Has This Been Tested?
Tested while testing updating from 0.15 to 0.16 on local and evonet, warnings and errors went away.


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
