### PR TITLE
fix: cannot read property ‘isDocumentDefined’ of null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,33 @@
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.27.tgz",
+          "integrity": "sha512-IeZlpkPnUqO45iBxJocIQzwV+K6phdSVaCxRwlvHHQ0YL+Gb1fvuv9GmIMYllZcjyzqoRKDNJeNo6p8dNWSPSQ=="
+        },
+        "protobufjs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
+          "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": "^13.7.0",
+            "long": "^4.0.0"
+          }
+        }
       }
     },
     "@jsdevtools/ono": {
@@ -1630,13 +1657,13 @@
       "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "dash": {
-      "version": "github:dashevo/js-dash-sdk#bee08e9a46e3dda9027a39e22c8f17c670bd3419",
+      "version": "github:dashevo/js-dash-sdk#a6ff304319e601a2f5cd158617f3c54d67d721fd",
       "from": "github:dashevo/js-dash-sdk#update-dpp",
       "requires": {
-        "@dashevo/dapi-client": "~0.16.0-dev.8",
+        "@dashevo/dapi-client": "~0.16.0-dev.1",
         "@dashevo/dashcore-lib": "~0.18.12",
-        "@dashevo/dpp": "~0.16.0-dev.9",
-        "@dashevo/wallet-lib": "github:dashevo/wallet-lib#bump-version",
+        "@dashevo/dpp": "~0.16.0-dev.2",
+        "@dashevo/wallet-lib": "~7.16.0-dev.1",
         "bs58": "^4.0.1"
       }
     },

--- a/src/listr/tasks/platform/initTaskFactory.js
+++ b/src/listr/tasks/platform/initTaskFactory.js
@@ -103,10 +103,10 @@ function initTaskFactory(
       {
         title: 'Register top level domain "dash"',
         task: async (ctx) => {
-          // noinspection JSAccessibilityCheck
-          ctx.client.apps.dpns = {
+          ctx.client.getApps().set('dpns', {
             contractId: ctx.dataContract.getId(),
-          };
+            contract: ctx.dataContract,
+          });
 
           await ctx.client.platform.names.register('dash', {
             dashAliasIdentityId: ctx.identity.getId(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`cannot read property ‘isDocumentDefined’ of null` error is throwing due to using old way to define application. 

## What was done?
<!--- Describe your changes in detail -->
Used new `Client#getApps#set` methods chain.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
