### PR TITLE
docs: cannot mint dash on evonet

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Before registering the masternode, you must have access to an address on the net
 dumpprivkey "address"
 ```
 
-If using a config specifying the `local` or `evonet` network, you can create and fund a new address using the `wallet` command as shown below.
+If using a config specifying the `local` network, you can create and fund a new address using the `wallet` command as shown below.
 
 ```
 USAGE


### PR DESCRIPTION
Fix incorrect docs raised in #169 

## Issue being fixed or feature implemented
It is not possible to mint Dash on evonet. Docs need updating to reflect this.


## What was done?
Remove docs indicating mint works on evonet


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
