### PR TITLE
fix: use conf sections for testnet

### DIFF
--- a/configs/testnet/core/dashd.conf
+++ b/configs/testnet/core/dashd.conf
@@ -8,7 +8,6 @@ maxconnections=256
 
 # JSONRPC
 server=1
-rpcport=20002
 rpcuser=dashrpc
 rpcpassword=password
 
@@ -22,8 +21,11 @@ rpcthreads=16
 
 # external network
 listen=1
-bind=0.0.0.0
 dnsseed=0
 allowprivatenet=0
 
 printtoconsole=1
+
+[test]
+bind=0.0.0.0
+rpcport=20002


### PR DESCRIPTION
Sentinel could not connect on testnet due to update to Dash Core 0.16 with different `dash.conf` format

## Issue being fixed or feature implemented
RPC was not configured properly


## What was done?
Move RPC conf details into `[test]` section


## How Has This Been Tested?
`mn start` with testnet conf works, sentinel container is not restarting and showing results from Core RPC


## Breaking Changes
none


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
