### PR TITLE
feat: update envoy for multi-arch support

### DIFF
--- a/src/config/systemConfigs/systemConfigs.js
+++ b/src/config/systemConfigs/systemConfigs.js
@@ -38,7 +38,7 @@ const baseConfig = {
     dapi: {
       envoy: {
         docker: {
-          image: 'envoyproxy/envoy:v1.14-latest',
+          image: 'envoyproxy/envoy:v1.16-latest',
         },
       },
       nginx: {


### PR DESCRIPTION
Updates envoy version to 1.16, the first release to officially support ARM architecture.

## Issue being fixed or feature implemented
This updates envoy to a version with ARM support so we can begin to support the evo stack on devices like Raspberry Pi or AWS Graviton2.


## What was done?
Bump envoy version


## How Has This Been Tested?
Tested locally to see if anything fails to load, everything seems fine. Envoy logs contain a few new messages about deprecated config syntax, in addition to a few deprecation notices that were already present in 1.14 logs. I can try to fix this, or someone with a better understanding of what envoy is doing in the evo stack could do it instead.

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
