### PR TITLE
feat: implement rate limiter in config

### DIFF
--- a/src/config/configJsonSchema.js
+++ b/src/config/configJsonSchema.js
@@ -187,9 +187,11 @@ module.exports = {
                       minimum: 0,
                     },
                   },
+                  required: ['enable', 'rate', 'burst'],
+                  additionalProperties: false,
                 },
               },
-              required: ['docker', 'http', 'grpc'],
+              required: ['docker', 'http', 'grpc', 'rateLimiter'],
               additionalProperties: false,
             },
             api: {

--- a/src/config/configJsonSchema.js
+++ b/src/config/configJsonSchema.js
@@ -172,6 +172,22 @@ module.exports = {
                   required: ['port'],
                   additionalProperties: false,
                 },
+                rateLimiter: {
+                  type: 'object',
+                  properties: {
+                    enable: {
+                      type: 'boolean',
+                    },
+                    rate: {
+                      type: 'integer',
+                      minimum: 0,
+                    },
+                    burst: {
+                      type: 'integer',
+                      minimum: 0,
+                    },
+                  },
+                },
               },
               required: ['docker', 'http', 'grpc'],
               additionalProperties: false,

--- a/src/config/systemConfigs/systemConfigs.js
+++ b/src/config/systemConfigs/systemConfigs.js
@@ -51,6 +51,11 @@ const baseConfig = {
         docker: {
           image: 'nginx:latest',
         },
+        rateLimiter: {
+          enable: true,
+          rate: 120,
+          burst: 300,
+        },
       },
       api: {
         docker: {
@@ -112,6 +117,15 @@ module.exports = {
   base: baseConfig,
   local: lodashMerge({}, baseConfig, {
     description: 'standalone node for local development',
+    platform: {
+      dapi: {
+        nginx: {
+          rateLimiter: {
+            enable: false,
+          },
+        },
+      },
+    },
     externalIp: '127.0.0.1',
     environment: 'development',
     network: NETWORKS.LOCAL,

--- a/templates/default.conf.template
+++ b/templates/default.conf.template
@@ -1,11 +1,11 @@
-limit_req_zone $binary_remote_addr zone=protect_api:15m rate=120r/m;
+{{? it.platform.dapi.nginx.rateLimiter.enable}}limit_req_zone $binary_remote_addr zone=protect_api:15m rate={{=it.platform.dapi.nginx.rateLimiter.rate}}/m;
 
-server {
+{{?}}server {
     listen 80 default_server;
-
-    limit_req zone=protect_api burst=300 nodelay;
+    {{? it.platform.dapi.nginx.rateLimiter.enable}}
+    limit_req zone=protect_api burst={{=it.platform.dapi.nginx.rateLimiter.burst}} nodelay;
     limit_req_status 429;
-
+    {{?}}
     access_log /tmp/access_log.log;
     error_log /tmp/error.log debug;
 

--- a/templates/grpc.conf.template
+++ b/templates/grpc.conf.template
@@ -14,10 +14,10 @@ server {
     listen 50051 http2;
 
     access_log /dev/stdout grpc_json;
-
-    limit_req zone=protect_api burst=300 nodelay;
+    {{? it.platform.dapi.nginx.rateLimiter.enable}}
+    limit_req zone=protect_api burst={{=it.platform.dapi.nginx.rateLimiter.burst}} nodelay;
     limit_req_status 429;
-
+    {{?}}
     location = /org.dash.platform.dapi.v0.Core/subscribeToTransactionsWithProofs {
         grpc_pass grpc://dapi_tx_filter_stream:3006;
         grpc_buffer_size 128k;


### PR DESCRIPTION
This PR adds the nginx rate limiter to the config template.

## Issue being fixed or feature implemented
Resolves #182. Prior to use of templates, the local config did not enable the nginx rate limiter config. This was accidentally re-enabled in the templates, causing errors during testing. This PR allows the user to configure the rate limiter, and ensures it is off by default on in the local config.

## What was done?
Add enabled/rate/burst to config and nginx templates.


## How Has This Been Tested?
- [x] Tested against local network, rate limiter config is not included
- [x] Tested against evonet, rate limiter config is included

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
