### PR TITLE
fix: syntax error in nginx config

### DIFF
--- a/templates/default.conf.template
+++ b/templates/default.conf.template
@@ -1,4 +1,4 @@
-{{? it.platform.dapi.nginx.rateLimiter.enable}}limit_req_zone $binary_remote_addr zone=protect_api:15m rate={{=it.platform.dapi.nginx.rateLimiter.rate}}/m;
+{{? it.platform.dapi.nginx.rateLimiter.enable}}limit_req_zone $binary_remote_addr zone=protect_api:15m rate={{=it.platform.dapi.nginx.rateLimiter.rate}}r/m;
 
 {{?}}server {
     listen 80 default_server;


### PR DESCRIPTION
Fix syntax error introduced in #183 

## Issue being fixed or feature implemented
nginx was restarting with following error:
```
2020/12/10 20:59:13 [emerg] 1#1: invalid rate "rate=120/m" in /etc/nginx/conf.d/default.conf:1
nginx: [emerg] invalid rate "rate=120/m" in /etc/nginx/conf.d/default.conf:1
```

## What was done?
Added missing "r" to rate limit


## How Has This Been Tested?
Tested on evonet, nginx no longer throws error


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
