### PR TITLE
feat: expose `rawchainlocksig` and `zmqpubrawtxlocksig` from Core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4361,7 +4361,7 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "github:jawid-h/protobuf.js#264b99b2ab6e097ff5350a57055d754d44d8e703",
+      "version": "github:jawid-h/protobuf.js#8b91c72dca68fd6c418078fd2358c4969425dcdc",
       "from": "github:jawid-h/protobuf.js#fix/buffer-conversion",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/templates/dashd.conf.template
+++ b/templates/dashd.conf.template
@@ -28,12 +28,14 @@ addressindex=1
 timestampindex=1
 spentindex=1
 
-{{? it.network === 'testnet'}}testnet=1
-[test]{{??}}# ZeroMQ notifications (required for Insight)
+# ZeroMQ notifications (required for Insight)
 zmqpubrawtx=tcp://0.0.0.0:29998
 zmqpubrawtxlock=tcp://0.0.0.0:29998
 zmqpubhashblock=tcp://0.0.0.0:29998
-zmqpubrawchainlock=tcp://0.0.0.0:29998{{?}}
+zmqpubrawchainlocksig=tcp://0.0.0.0:29998
+
+{{? it.network === 'testnet'}}testnet=1
+[test]{{?}}
 {{? it.network === 'local'}}
 regtest=1
 [regtest]{{?? it.network === 'evonet'}}

--- a/templates/dashd.conf.template
+++ b/templates/dashd.conf.template
@@ -35,8 +35,8 @@ zmqpubhashblock=tcp://0.0.0.0:29998
 zmqpubrawchainlocksig=tcp://0.0.0.0:29998
 
 {{? it.network === 'testnet'}}testnet=1
-[test]{{?}}
-{{? it.network === 'local'}}
+[test]
+{{?? it.network === 'local'}}
 regtest=1
 [regtest]{{?? it.network === 'evonet'}}
 devnet={{=it.core.devnetName}}

--- a/templates/dashd.conf.template
+++ b/templates/dashd.conf.template
@@ -28,11 +28,12 @@ addressindex=1
 timestampindex=1
 spentindex=1
 
-# ZeroMQ notifications (required for Insight)
+# ZeroMQ notifications
 zmqpubrawtx=tcp://0.0.0.0:29998
 zmqpubrawtxlock=tcp://0.0.0.0:29998
 zmqpubhashblock=tcp://0.0.0.0:29998
 zmqpubrawchainlocksig=tcp://0.0.0.0:29998
+zmqpubrawtxlocksig=tcp://0.0.0.0:29998
 
 {{? it.network === 'testnet'}}testnet=1
 [test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Drive requires `rawchainlocksig` zmq socket instead of `rawchainlock`. DAPI requires `zmqpubrawtxlocksig`

## What was done?
<!--- Describe your changes in detail -->
Expose `rawchainlocksig` and `zmqpubrawtxlocksig` in dashd config instead of `rawchainlock`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run setup for local development command

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
