### PR TITLE
feat!: configure `passFakeAssetLockProofForTests`

### DIFF
--- a/src/config/configJsonSchema.js
+++ b/src/config/configJsonSchema.js
@@ -291,6 +291,9 @@ module.exports = {
             skipAssetLockConfirmationValidation: {
               type: 'boolean',
             },
+            passFakeAssetLockProofForTests: {
+              type: 'boolean',
+            },
           },
           required: ['mongodb', 'abci', 'tenderdash', 'skipAssetLockConfirmationValidation'],
           additionalProperties: false,

--- a/src/config/systemConfigs/systemConfigs.js
+++ b/src/config/systemConfigs/systemConfigs.js
@@ -104,6 +104,7 @@ const baseConfig = {
         },
       },
       skipAssetLockConfirmationValidation: false,
+      passFakeAssetLockProofForTests: false,
     },
     dpns: {
       contract: {
@@ -135,6 +136,7 @@ module.exports = {
       },
       drive: {
         skipAssetLockConfirmationValidation: true,
+        passFakeAssetLockProofForTests: true,
       },
     },
     externalIp: '127.0.0.1',

--- a/src/listr/tasks/platform/initTaskFactory.js
+++ b/src/listr/tasks/platform/initTaskFactory.js
@@ -62,7 +62,8 @@ function initTaskFactory(
             wallet: {
               mnemonic: null,
             },
-            passFakeAssetLockProofForTests: true,
+            passFakeAssetLockProofForTests:
+              config.get('platform.drive.passFakeAssetLockProofForTests', true),
           });
 
           const amount = 40000;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the local network there is no instant lock quorums atm, so we use fallbacks in Drive and need to pass fake instant lock messages. 

## What was done?
<!--- Describe your changes in detail -->
Introduced `platform.drive.passFakeAssetLockProofForTests` option which is enabled for local config.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
`platform.drive.passFakeAssetLockProofForTests` option is required.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
