### PR TITLE
fix: catch errors when calling services which might be down

### DIFF
--- a/src/commands/status/core.js
+++ b/src/commands/status/core.js
@@ -60,18 +60,30 @@ class CoreStatusCommand extends BaseCommand {
       tag_name: latestVersion,
     } = await latestVersionRes.json();
     latestVersion = latestVersion.substring(1);
-    const corePortStateRes = await fetch(`https://mnowatch.org/${config.options.core.p2p.port}/`);
-    let corePortState = await corePortStateRes.text();
+
+    let corePortStateRes;
+    let corePortState;
+    try {
+      corePortStateRes = await fetch(`https://mnowatch.org/${config.options.core.p2p.port}/`);
+      corePortState = await corePortStateRes.text();
+    } catch (e) {
+      corePortState = 'ERROR';
+    }
+
     let coreVersion = networkInfo.subversion.replace(/\/|\(.*?\)|Dash Core:/g, '');
     let explorerBlockHeightRes;
     let explorerBlockHeight;
     if (insightURLs[config.options.network]) {
-      explorerBlockHeightRes = await fetch(`${insightURLs[config.options.network]}/status`);
-      ({
-        info: {
-          blocks: explorerBlockHeight,
-        },
-      } = await explorerBlockHeightRes.json());
+      try {
+        explorerBlockHeightRes = await fetch(`${insightURLs[config.options.network]}/status`);
+        ({
+          info: {
+            blocks: explorerBlockHeight,
+          },
+        } = await explorerBlockHeightRes.json());
+      } catch (e) {
+        explorerBlockHeight = 0;
+      }
     }
     const sentinelVersion = (await dockerCompose.execCommand(
       config.toEnvs(),

--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -105,30 +105,47 @@ class StatusCommand extends BaseCommand {
         }
       } else if (coreIsSynced === true) {
         // Collecting platform data fails if Tenderdash is waiting for core to sync
-        const platformStatusRes = await fetch(`http://localhost:${config.get('platform.drive.tenderdash.rpc.port')}/status`);
-
-        ({
-          result: {
-            node_info: {
-              version: platformVersion,
+        try {
+          const platformStatusRes = await fetch(`http://localhost:${config.get('platform.drive.tenderdash.rpc.port')}/status`);
+          ({
+            result: {
+              node_info: {
+                version: platformVersion,
+              },
+              sync_info: {
+                latest_block_height: platformBlockHeight,
+                catching_up: platformCatchingUp,
+              },
             },
-            sync_info: {
-              latest_block_height: platformBlockHeight,
-              catching_up: platformCatchingUp,
-            },
-          },
-        } = await platformStatusRes.json());
+          } = await platformStatusRes.json());
+        } catch (e) {
+          platformVersion = 'unknown';
+          platformBlockHeight = 0;
+          platformCatchingUp = false;
+        }
       }
     }
 
-    const explorerBlockHeightRes = await fetch('https://rpc.cloudwheels.net:26657/status');
-    const {
-      result: {
-        sync_info: {
-          latest_block_height: explorerBlockHeight,
+    const platformExplorerURLs = {
+      evonet: 'https://rpc.cloudwheels.net:26657',
+      testnet: '',
+      mainnet: '',
+    };
+
+    let explorerBlockHeightRes;
+    let explorerBlockHeight;
+    try {
+      explorerBlockHeightRes = await fetch(`${platformExplorerURLs[config.options.network]}/status`);
+      ({
+        result: {
+          sync_info: {
+            latest_block_height: explorerBlockHeight,
+          },
         },
-      },
-    } = await explorerBlockHeightRes.json();
+      } = await explorerBlockHeightRes.json());
+    } catch (e) {
+      explorerBlockHeightRes = 0;
+    }
 
     // Determine status
     let coreStatus;

--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -119,9 +119,13 @@ class StatusCommand extends BaseCommand {
             },
           } = await platformStatusRes.json());
         } catch (e) {
-          platformVersion = 'unknown';
-          platformBlockHeight = 0;
-          platformCatchingUp = false;
+          if (e.name === 'FetchError') {
+            platformVersion = 'unknown';
+            platformBlockHeight = 0;
+            platformCatchingUp = false;
+          } else {
+            throw new Error(e);
+          }
         }
       }
     }
@@ -132,10 +136,9 @@ class StatusCommand extends BaseCommand {
       mainnet: '',
     };
 
-    let explorerBlockHeightRes;
     let explorerBlockHeight;
     try {
-      explorerBlockHeightRes = await fetch(`${platformExplorerURLs[config.options.network]}/status`);
+      const explorerBlockHeightRes = await fetch(`${platformExplorerURLs[config.options.network]}/status`);
       ({
         result: {
           sync_info: {
@@ -144,7 +147,11 @@ class StatusCommand extends BaseCommand {
         },
       } = await explorerBlockHeightRes.json());
     } catch (e) {
-      explorerBlockHeightRes = 0;
+      if (e.name === 'FetchError') {
+        explorerBlockHeight = 0;
+      } else {
+        throw new Error(e);
+      }
     }
 
     // Determine status

--- a/src/commands/status/platform.js
+++ b/src/commands/status/platform.js
@@ -90,23 +90,44 @@ class CoreStatusCommand extends BaseCommand {
 
     let explorerLatestBlockHeight;
     if (explorerURLs[config.options.network]) {
-      const explorerBlockHeightRes = await fetch(explorerURLs[config.options.network]);
-      ({
-        result: {
-          sync_info: {
-            latest_block_height: explorerLatestBlockHeight,
+      try {
+        const explorerBlockHeightRes = await fetch(explorerURLs[config.options.network]);
+        ({
+          result: {
+            sync_info: {
+              latest_block_height: explorerLatestBlockHeight,
+            },
           },
-        },
-      } = await explorerBlockHeightRes.json());
+        } = await explorerBlockHeightRes.json());
+      } catch (e) {
+        if (e.name === 'FetchError') {
+          explorerLatestBlockHeight = 0;
+        } else {
+          throw new Error(e);
+        }
+      }
     }
 
     // Check ports
-    const httpPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.dapi.nginx.http.port}/`);
-    let httpPortState = await httpPortStateRes.text();
-    const gRpcPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.dapi.nginx.grpc.port}/`);
-    let gRpcPortState = await gRpcPortStateRes.text();
-    const p2pPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.drive.tenderdash.p2p.port}/`);
-    let p2pPortState = await p2pPortStateRes.text();
+    let httpPortState;
+    let gRpcPortState;
+    let p2pPortState;
+    try {
+      const httpPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.dapi.nginx.http.port}/`);
+      httpPortState = await httpPortStateRes.text();
+      const gRpcPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.dapi.nginx.grpc.port}/`);
+      gRpcPortState = await gRpcPortStateRes.text();
+      const p2pPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.drive.tenderdash.p2p.port}/`);
+      p2pPortState = await p2pPortStateRes.text();
+    } catch (e) {
+      if (e.name === 'FetchError') {
+        httpPortState = 'ERROR';
+        gRpcPortState = 'ERROR';
+        p2pPortState = 'ERROR';
+      } else {
+        throw new Error(e);
+      }
+    }
 
     // Determine status
     let status;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
Catches errors and substitutes sensible defaults instead.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
mn was crashing when insight, tenderdash or mnowatch were not available. 

## What was done?
<!--- Describe your changes in detail -->
Catch previously uncaught errors and substitute sensible defaults instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and on testnet masternode while syncing. 

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
