### PR TITLE
feat: show progress output for up command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,18 +15,18 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true
     },
     "@babel/highlight": {
@@ -79,15 +79,29 @@
       }
     },
     "@dashevo/dapi-client": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.17.2.tgz",
-      "integrity": "sha512-lWaAXNwf1yVtI9fccgu2wYjNlkKsOgdvmIAEkSN45ALrg3sEMjY2p4QiEJV55IZVzC3j6+nC+iG3QO6dY7ZGcQ==",
+      "version": "0.18.0-dev.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.18.0-dev.1.tgz",
+      "integrity": "sha512-2i8hKoFkMEOTzszrprBZqJx0Yr6E5dv2y5VMYxhqPpvsxs4jDmhIh8kLfTyXc5vnwmAJ/z3Ufj+6/aDmSB67hQ==",
       "requires": {
-        "@dashevo/dapi-grpc": "~0.17.0",
+        "@dashevo/dapi-grpc": "~0.18.0-dev.2",
         "@dashevo/dashcore-lib": "~0.19.19",
         "axios": "^0.19.2",
         "cbor": "^5.0.1",
         "lodash.sample": "^4.2.1"
+      },
+      "dependencies": {
+        "@dashevo/dapi-grpc": {
+          "version": "0.18.0-dev.2",
+          "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.18.0-dev.2.tgz",
+          "integrity": "sha512-0/530EWRMFLj1QBvfY+0CXHbuJjnWMDvCI+6GcFVzYprerIayQe9Wgr1l4gmplQjI06WJd+GXdk4W+mEpxImYQ==",
+          "requires": {
+            "@dashevo/grpc-common": "^0.3.0",
+            "google-protobuf": "^3.12.2",
+            "grpc": "^1.24.3",
+            "grpc-web": "^1.2.0",
+            "protobufjs": "github:jawid-h/protobuf.js#fix/buffer-conversion"
+          }
+        }
       }
     },
     "@dashevo/dapi-grpc": {
@@ -140,9 +154,9 @@
       "from": "github:dashevo/dashpay-contract#bc4e9b2d0073e27bd716b3ae63ccfdd60d8c4f36"
     },
     "@dashevo/dpns-contract": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-0.3.0.tgz",
-      "integrity": "sha512-tzrXwJS57jpLu0ow69WARb0iC977osfrZ+UPljrAhQVOaBqyMaf4bQunGKdEAh9JIqXgS+3vEsxhD7+qn6auzA=="
+      "version": "0.3.0-dev.6",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-0.3.0-dev.6.tgz",
+      "integrity": "sha512-aRXv9UmkZSh9KJvFFo3W+bFhkn1g4O01sEXoaZZd5ZXy5q6U1MGOsFG2jaTILKwT0/wq2iHCc0PeCFAYpfjs6w=="
     },
     "@dashevo/dpp": {
       "version": "0.17.0",
@@ -187,6 +201,20 @@
         "lodash": "^4.17.19",
         "pbkdf2": "^3.1.1",
         "winston": "^3.2.1"
+      },
+      "dependencies": {
+        "@dashevo/dapi-client": {
+          "version": "0.17.2",
+          "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.17.2.tgz",
+          "integrity": "sha512-lWaAXNwf1yVtI9fccgu2wYjNlkKsOgdvmIAEkSN45ALrg3sEMjY2p4QiEJV55IZVzC3j6+nC+iG3QO6dY7ZGcQ==",
+          "requires": {
+            "@dashevo/dapi-grpc": "~0.17.0",
+            "@dashevo/dashcore-lib": "~0.19.19",
+            "axios": "^0.19.2",
+            "cbor": "^5.0.1",
+            "lodash.sample": "^4.2.1"
+          }
+        }
       }
     },
     "@dashevo/x11-hash-js": {
@@ -195,9 +223,9 @@
       "integrity": "sha512-3vvnZweBca4URBXHF+FTrM4sdTpp3IMt73G1zUKQEdYm/kJkIKN94qpFai7YZDl87k64RCH+ckRZk6ruQPz5KQ=="
     },
     "@grpc/proto-loader": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.6.tgz",
-      "integrity": "sha512-DT14xgw3PSzPxwS13auTEwxhMMOoz33DPUKNtmYK/QYbBSpLXJy78FGGs5yVoxVobEqPm4iW9MOIoz0A3bLTRQ==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.5.tgz",
+      "integrity": "sha512-WwN9jVNdHRQoOBo9FDH7qU+mgfjPc8GygPYms3M+y3fbQLfnCe/Kv/E01t7JRgnrsOHH8euvSbed3mIalXhwqQ==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
@@ -209,25 +237,25 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
-      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
       "requires": {
-        "@nodelib/fs.stat": "2.0.4",
+        "@nodelib/fs.stat": "2.0.3",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
-      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
       "requires": {
-        "@nodelib/fs.scandir": "2.1.4",
+        "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
     },
@@ -245,13 +273,12 @@
       },
       "dependencies": {
         "@oclif/plugin-help": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.1.tgz",
-          "integrity": "sha512-vq7rn16TrQmjX3Al/k1Z5iBZWZ3HE8fDXs52OmDJmmTqryPSNvURH9WCAsqr0PODYCSR17Hy1VTzS0x7vVVLEQ==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.0.tgz",
+          "integrity": "sha512-7jxtpwVWAVbp1r46ZnTK/uF+FeZc6y4p1XcGaIUuPAp7wx6NJhIRN/iMT9UfNFX/Cz7mq+OyJz+E+i0zrik86g==",
           "requires": {
             "@oclif/command": "^1.5.20",
             "@oclif/config": "^1.15.1",
-            "@oclif/errors": "^1.2.2",
             "chalk": "^2.4.1",
             "indent-string": "^4.0.0",
             "lodash.template": "^4.4.0",
@@ -388,9 +415,9 @@
           }
         },
         "globby": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-          "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
           "requires": {
             "array-union": "^2.1.0",
             "dir-glob": "^3.0.1",
@@ -408,9 +435,9 @@
       }
     },
     "@oclif/dev-cli": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@oclif/dev-cli/-/dev-cli-1.26.0.tgz",
-      "integrity": "sha512-272udZP+bG4qahoAcpWcMTJKiA+V42kRMqQM7n4tgW35brYb2UP5kK+p08PpF8sgSfRTV8MoJVJG9ax5kY82PA==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@oclif/dev-cli/-/dev-cli-1.25.1.tgz",
+      "integrity": "sha512-q+ywUIRa1SB9A+hIFXlvzWc5oeYgI1sBiFyYrV775lyNC7uVldRCKJ9MVi+YBXZxp7hXeh6r0dC7K2mrOryaJQ==",
       "dev": true,
       "requires": {
         "@oclif/command": "^1.8.0",
@@ -429,14 +456,13 @@
       },
       "dependencies": {
         "@oclif/plugin-help": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.1.tgz",
-          "integrity": "sha512-vq7rn16TrQmjX3Al/k1Z5iBZWZ3HE8fDXs52OmDJmmTqryPSNvURH9WCAsqr0PODYCSR17Hy1VTzS0x7vVVLEQ==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.0.tgz",
+          "integrity": "sha512-7jxtpwVWAVbp1r46ZnTK/uF+FeZc6y4p1XcGaIUuPAp7wx6NJhIRN/iMT9UfNFX/Cz7mq+OyJz+E+i0zrik86g==",
           "dev": true,
           "requires": {
             "@oclif/command": "^1.5.20",
             "@oclif/config": "^1.15.1",
-            "@oclif/errors": "^1.2.2",
             "chalk": "^2.4.1",
             "indent-string": "^4.0.0",
             "lodash.template": "^4.4.0",
@@ -893,9 +919,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.18",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.18.tgz",
-      "integrity": "sha512-m4JTwx5RUBNZvky/JJ8swEJPKFd8si08pPF2PfizYjGZOKr/svUWPcoUmLow6MmPzhasphB7gSTINY67xn3JNA==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.15.tgz",
+      "integrity": "sha512-pb71P0BrBAx7cQE+/7QnA1HTQUkdBKMlkPY7lHUMn0YvPJkL2UA+KW3BdWQ309IT+i9En/qm45ZxpjIcpgEhNQ==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -926,9 +952,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+      "version": "4.14.165",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
+      "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg=="
     },
     "@types/long": {
       "version": "4.0.1",
@@ -941,9 +967,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "12.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-      "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
+      "version": "12.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
+      "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg=="
     },
     "@types/qs": {
       "version": "6.9.5",
@@ -1313,13 +1339,13 @@
       }
     },
     "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "get-intrinsic": "^1.0.0"
       }
     },
     "call-me-maybe": {
@@ -1358,11 +1384,11 @@
       }
     },
     "cbor": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.1.0.tgz",
+      "integrity": "sha512-qzEc7kUShdMbWTaUH7X+aHW8owvBU3FS0dfYR1lGYpoZr0mGJhhojLlZJH653x/DfeMZ56h315FRNBUIG1R7qg==",
       "requires": {
-        "bignumber.js": "^9.0.1",
+        "bignumber.js": "^9.0.0",
         "nofilter": "^1.0.4"
       }
     },
@@ -1766,39 +1792,16 @@
       "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "dash": {
-      "version": "github:dashevo/js-dash-sdk#4fca09990b122eeb58020b855a7c51f9afa3e58a",
+      "version": "github:dashevo/js-dash-sdk#d8a50d3ca7f62c73d70f06ab6f2b79ca8c90e73d",
       "from": "github:dashevo/js-dash-sdk#feat-wait-for-st-result",
       "requires": {
-        "@dashevo/dapi-client": "github:dashevo/dapi-client#wait-for-state-transition-result",
+        "@dashevo/dapi-client": "0.18.0-dev.1",
         "@dashevo/dashcore-lib": "~0.19.19",
         "@dashevo/dpp": "~0.18.0-dev.1",
-        "@dashevo/wallet-lib": "~7.17.2",
+        "@dashevo/wallet-lib": "~7.18.0-dev.1",
         "bs58": "^4.0.1"
       },
       "dependencies": {
-        "@dashevo/dapi-client": {
-          "version": "github:dashevo/dapi-client#4e940baef8e08c4b21e19c904587d1480155d851",
-          "from": "github:dashevo/dapi-client#wait-for-state-transition-result",
-          "requires": {
-            "@dashevo/dapi-grpc": "~0.18.0-dev.2",
-            "@dashevo/dashcore-lib": "~0.19.19",
-            "axios": "^0.19.2",
-            "cbor": "^5.0.1",
-            "lodash.sample": "^4.2.1"
-          }
-        },
-        "@dashevo/dapi-grpc": {
-          "version": "0.18.0-dev.2",
-          "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.18.0-dev.2.tgz",
-          "integrity": "sha512-0/530EWRMFLj1QBvfY+0CXHbuJjnWMDvCI+6GcFVzYprerIayQe9Wgr1l4gmplQjI06WJd+GXdk4W+mEpxImYQ==",
-          "requires": {
-            "@dashevo/grpc-common": "^0.3.0",
-            "google-protobuf": "^3.12.2",
-            "grpc": "^1.24.3",
-            "grpc-web": "^1.2.0",
-            "protobufjs": "github:jawid-h/protobuf.js#fix/buffer-conversion"
-          }
-        },
         "@dashevo/dpp": {
           "version": "0.18.0-dev.1",
           "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.18.0-dev.1.tgz",
@@ -1814,6 +1817,22 @@
             "lodash.get": "^4.4.2",
             "lodash.mergewith": "^4.6.2",
             "lodash.set": "^4.3.2"
+          }
+        },
+        "@dashevo/wallet-lib": {
+          "version": "7.18.0-dev.1",
+          "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-7.18.0-dev.1.tgz",
+          "integrity": "sha512-euRhU8rBMHKfHWJJ1stEtNhXIXrazJBYWvV01D8jTyXKYWB0vsG0BTEjzjxbkEntf6RoVvJUz2B9GMXWZ2rLcg==",
+          "requires": {
+            "@dashevo/dapi-client": "~0.18.0-dev.1",
+            "@dashevo/dashcore-lib": "~0.19.19",
+            "@dashevo/dpp": "~0.18.0-dev.1",
+            "@dashevo/grpc-common": "~0.3.2",
+            "cbor": "^5.0.2",
+            "crypto-js": "^4.0.0",
+            "lodash": "^4.17.19",
+            "pbkdf2": "^3.1.1",
+            "winston": "^3.2.1"
           }
         }
       }
@@ -1905,9 +1924,9 @@
       }
     },
     "docker-compose": {
-      "version": "0.23.6",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.6.tgz",
-      "integrity": "sha512-y3Q8MkwG862rNqkvEQG59/7Fi2/fzs3NYDCvqUAAD+z0WGs2qcJ9hRcn34hWgWv9ouPkFqe3Vwca0h+4bIIRWw=="
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.5.tgz",
+      "integrity": "sha512-y3swhij4q3pyX45kJH7OMHZjoHPfiaTe8RPAQQ9fbamKQHI+k+1HnZm0T9NbbMFusTn0het0eK4WjXGM+rcF2A=="
     },
     "docker-modem": {
       "version": "2.1.4",
@@ -2041,25 +2060,23 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0-next.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
         "is-callable": "^1.2.2",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.0",
         "is-regex": "^1.1.1",
-        "object-inspect": "^1.9.0",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.3",
-        "string.prototype.trimstart": "^1.0.3"
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -2531,9 +2548,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2560,9 +2577,9 @@
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastq": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
-      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -2735,9 +2752,9 @@
       }
     },
     "get-intrinsic": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
-      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -3054,9 +3071,9 @@
       }
     },
     "import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -3399,9 +3416,9 @@
       "dev": true
     },
     "jayson": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.4.4.tgz",
-      "integrity": "sha512-fgQflh+Qnhdv9fjxTnpTsa2WUG/dgyeKQzIh5MJ77Qv2sqFyyAZn7mTUYgPjJMFjsKfb4HNsSBh6ktJeeQiAGQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.3.4.tgz",
+      "integrity": "sha512-p2stl9m1C0vM8mdXM1m8shn0v5ECohD5gEDRzLD6CPv02pxRm1lv0jEz0HX6RvfJ/uO9z9Zzlzti7/uqq+Rh5g==",
       "requires": {
         "@types/connect": "^3.4.33",
         "@types/express-serve-static-core": "^4.17.9",
@@ -3551,9 +3568,9 @@
       },
       "dependencies": {
         "parse-json": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
@@ -3921,9 +3938,9 @@
       "dev": true
     },
     "needle": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
-      "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
+      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -4084,9 +4101,9 @@
       "dev": true
     },
     "object-treeify": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.31.tgz",
-      "integrity": "sha512-kt2UuyHDTH+J6w0pv2c+3uuEApGuwgfjWogbqPWAvk4nOM/T3No0SzDtp6CuJ/XBUy//nFNuerb8ms7CqjD9Tw==",
+      "version": "1.1.30",
+      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.30.tgz",
+      "integrity": "sha512-BhsTZj8kbeCnyBKWuAgAakbGgrcVV/IJhUAGF25lOSwDZoHoDmnynUtXfyrrDn8A1Xy3G9k5uLP+V5onOOq3WA==",
       "dev": true
     },
     "object.assign": {
@@ -4367,9 +4384,9 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "pretty-bytes": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
-      "integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
+      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA=="
     },
     "pretty-ms": {
       "version": "7.0.1",
@@ -4410,9 +4427,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.40",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.40.tgz",
-          "integrity": "sha512-eKaRo87lu1yAXrzEJl0zcJxfUMDT5/mZalFyOkT44rnQps41eS2pfWzbaulSPpQLFNy29bFqn+Y5lOTL8ATlEQ=="
+          "version": "13.13.38",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.38.tgz",
+          "integrity": "sha512-oxo8j9doh7ab9NwDA9bCeFfjHRF/uzk+fTljCy8lMjZ3YzZGAXNDKhTE3Byso/oy32UTUQIXB3HCVHu3d2T3xg=="
         }
       }
     },
@@ -4908,9 +4925,9 @@
       }
     },
     "sort-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
-      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.1.0.tgz",
+      "integrity": "sha512-/sRdxzkkPFUYiCrTr/2t+104nDc9AgDmEpeVYuvOWYQe3Djk1GWO6lVw3Vx2jfh1SsR0eehhd1nvFYlzt5e99w==",
       "dev": true,
       "requires": {
         "is-plain-obj": "^2.0.0"
@@ -5186,9 +5203,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -5289,9 +5306,9 @@
       }
     },
     "tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -5341,9 +5358,9 @@
       "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
     },
     "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -5534,9 +5551,9 @@
       }
     },
     "y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
       "version": "3.1.1",

--- a/src/docker/DockerCompose.js
+++ b/src/docker/DockerCompose.js
@@ -233,7 +233,7 @@ class DockerCompose {
       return dockerCompose.pullAll({
         ...this.getOptions(envs),
         log: true,
-      }).out;
+      });
     } catch (e) {
       throw new DockerComposeError(e);
     }

--- a/src/docker/DockerCompose.js
+++ b/src/docker/DockerCompose.js
@@ -230,10 +230,10 @@ class DockerCompose {
     await this.throwErrorIfNotInstalled();
 
     try {
-      await dockerCompose.pullAll({
+      return dockerCompose.pullAll({
         ...this.getOptions(envs),
-        commandOptions: ['-q'],
-      });
+        log: true,
+      }).out;
     } catch (e) {
       throw new DockerComposeError(e);
     }

--- a/src/docker/DockerCompose.js
+++ b/src/docker/DockerCompose.js
@@ -93,10 +93,11 @@ class DockerCompose {
     await this.throwErrorIfNotInstalled();
 
     try {
-      await dockerCompose.upAll({
+      return dockerCompose.upAll({
         ...this.getOptions(envs),
+        log: true,
         commandOptions: ['--build'],
-      });
+      }).out;
     } catch (e) {
       throw new DockerComposeError(e);
     }

--- a/src/listr/tasks/startNodeTaskFactory.js
+++ b/src/listr/tasks/startNodeTaskFactory.js
@@ -57,7 +57,7 @@ function startNodeTaskFactory(dockerCompose) {
       },
       {
         title: 'Start services',
-        task: async () => {
+        task: async (task) => {
           const isMasternode = config.get('core.masternode.enable');
           if (isMasternode) {
             // Check operatorPrivateKey is set
@@ -82,7 +82,8 @@ function startNodeTaskFactory(dockerCompose) {
             }
           }
 
-          await dockerCompose.up(envs);
+          // eslint-disable-next-line no-param-reassign
+          task.output = dockerCompose.up(envs);
         },
       },
       {

--- a/src/listr/tasks/startNodeTaskFactory.js
+++ b/src/listr/tasks/startNodeTaskFactory.js
@@ -55,62 +55,15 @@ function startNodeTaskFactory(dockerCompose) {
       {
         title: 'Download updated services',
         task: async (ctx, task) => {
-          // async function waitStream() {
-          //   // eslint-disable-next-line no-new
-          //   new Promise((resolve, reject) => {
-          //     const pullCommand = dockerCompose.pull(config.toEnvs());
-          //     // eslint-disable-next-line no-param-reassign
-          //     task.output = pullCommand.out;
-          //     pullCommand.then(resolve)
-          //       .catch(() => reject(new Error('Updating services failed')));
-          //   });
-          // }
-          // await waitStream();
+          async function logChunks(readable) {
+            for await (const chunk of readable) {
+              task.output = chunk.out;
+            }
+          }
 
-          // Doesn't wait
+          const log = await dockerCompose.pull(config.toEnvs());
 
-          // ---------------------------------------------------------------------
-
-          // await new Promise((resolve, reject) => {
-          //   const readable = Readable.from(dockerCompose.pull(config.toEnvs()));
-          //   readable.on('data', (chunk) => {
-          //     // eslint-disable-next-line no-param-reassign
-          //     task.output = chunk;
-          //   });
-          //   readable.on('end', resolve);
-          //   readable.on('error', (error) => {
-          //     throw new Error(error);
-          //   });
-          // });
-
-          // The "iterable" argument must be an instance of Iterable. Received an instance of Promise
-
-          // ---------------------------------------------------------------------
-
-          // let streamy = '';
-          // const theObserver = new Observable((observer) => {
-          //   streamy = from(dockerCompose.pull(config.toEnvs()));
-          // });
-          // theObserver.subscribe(task.output);
-          // streamy.pipe(task.output);
-
-          // pipe_1.pipeFromArray(...) is not a function
-
-          // ---------------------------------------------------------------------
-
-          // eslint-disable-next-line no-new
-          // await new Promise((resolve, reject) => {
-          //   const pullCommand = dockerCompose.pull(config.toEnvs());
-          //   const streamy = from(pullCommand);
-          //   streamy.pipe(task.output);
-          //   pullCommand.then(resolve)
-          //     .catch(() => reject(new Error('Updating services failed')));
-          //   // pullCommand.stdout.pipe(task.output);
-          // });
-          // eslint-disable-next-line no-param-reassign
-          // task.output = await dockerCompose.pull(config.toEnvs());
-
-          // pipe_1.pipeFromArray(...) is not a function
+          logChunks(log);
         },
       },
       // Why do we need to build if images are already available on Docker Hub?


### PR DESCRIPTION
This PR attempts to resolve #208 by piping docker-compose output to the Listr task.

## Issue being fixed or feature implemented
The `start` command calls `docker-compose up` which can be slow if images have not been downloaded yet. Previously no status was displayed, which could leave the user thinking mn-bootstrap was hanging or unresponsive.


## What was done?
Return log output from `docker-compose.upAll` to the listr function which originally called it


## How Has This Been Tested?
Tried it with normal startup and when downloading an image.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
