### PR TITLE
fix: status command returns TypeError

### DIFF
--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -137,21 +137,25 @@ class StatusCommand extends BaseCommand {
     };
 
     let explorerBlockHeight;
-    try {
-      const explorerBlockHeightRes = await fetch(`${platformExplorerURLs[config.options.network]}/status`);
-      ({
-        result: {
-          sync_info: {
-            latest_block_height: explorerBlockHeight,
+    if (platformExplorerURLs[config.options.network] !== '') {
+      try {
+        const explorerBlockHeightRes = await fetch(`${platformExplorerURLs[config.options.network]}/status`);
+        ({
+          result: {
+            sync_info: {
+              latest_block_height: explorerBlockHeight,
+            },
           },
-        },
-      } = await explorerBlockHeightRes.json());
-    } catch (e) {
-      if (e.name === 'FetchError') {
-        explorerBlockHeight = 0;
-      } else {
-        throw e;
+        } = await explorerBlockHeightRes.json());
+      } catch (e) {
+        if (e.name === 'FetchError') {
+          explorerBlockHeight = 0;
+        } else {
+          throw e;
+        }
       }
+    } else {
+      explorerBlockHeight = 0;
     }
 
     // Determine status


### PR DESCRIPTION
Fix unsafely using potentially blank variable in fetch command.

## Issue being fixed or feature implemented
Running `mn status` on testnet resulted in: `TypeError: Only absolute URLs are supported`


## What was done?
Check variable is not blank before running query


## How Has This Been Tested?
On testnet, no longer throws error

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
