### PR TITLE
feat: include sentinel image version in config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - -masternodeblsprivkey=${CORE_MASTERNODE_OPERATOR_PRIVATE_KEY}
 
   sentinel:
-    image: dashpay/sentinel
+    image: ${CORE_DOCKER_IMAGE:?err}
     restart: unless-stopped
     depends_on:
       - core

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - -masternodeblsprivkey=${CORE_MASTERNODE_OPERATOR_PRIVATE_KEY}
 
   sentinel:
-    image: ${CORE_DOCKER_IMAGE:?err}
+    image: ${CORE_SENTINEL_DOCKER_IMAGE:?err}
     restart: unless-stopped
     depends_on:
       - core

--- a/src/config/configJsonSchema.js
+++ b/src/config/configJsonSchema.js
@@ -148,6 +148,14 @@ module.exports = {
           required: ['enable', 'interval', 'address'],
           additionalProperties: false,
         },
+        sentinel: {
+          type: 'object',
+          properties: {
+            docker: {
+              $ref: '#/definitions/docker/properties/docker',
+            },
+          },
+        },
         devnetName: {
           type: ['string', 'null'],
           minLength: 1,

--- a/src/config/configOptionMigrations.js
+++ b/src/config/configOptionMigrations.js
@@ -25,7 +25,7 @@ module.exports = {
 
     return options;
   },
-  '0.17.8': (name, options) => {
+  '0.18.0': (name, options) => {
     lodashSet(options, 'core.sentinel.docker.image', 'dashpay/sentinel:1.5.0');
 
     return options;

--- a/src/config/configOptionMigrations.js
+++ b/src/config/configOptionMigrations.js
@@ -46,7 +46,7 @@ module.exports = {
     }
   },
   '0.18.0': (name, options) => {
-    lodashSet(options, 'core.sentinel.docker.image', 'dashpay/sentinel:1.5.0');
+    lodashSet(options, 'core.sentinel', systemConfigs.base.core.sentinel);
 
     return options;
   },

--- a/src/config/configOptionMigrations.js
+++ b/src/config/configOptionMigrations.js
@@ -26,7 +26,6 @@ module.exports = {
 
     return options;
   },
-
   '0.17.4': (name, options) => {
     let baseConfig = systemConfigs.base;
     if (systemConfigs[name]) {
@@ -46,7 +45,6 @@ module.exports = {
       lodashSet(options, 'platform.drive.abci.log.stdout.level', previousStdoutLogLevel);
     }
   },
-
   '0.18.0': (name, options) => {
     lodashSet(options, 'core.sentinel.docker.image', 'dashpay/sentinel:1.5.0');
 

--- a/src/config/configOptionMigrations.js
+++ b/src/config/configOptionMigrations.js
@@ -25,4 +25,9 @@ module.exports = {
 
     return options;
   },
+  '0.17.8': (name, options) => {
+    lodashSet(options, 'core.sentinel.docker.image', 'dashpay/sentinel:1.5.0');
+
+    return options;
+  },
 };

--- a/src/config/systemConfigs/systemConfigs.js
+++ b/src/config/systemConfigs/systemConfigs.js
@@ -32,6 +32,11 @@ const baseConfig = {
       interval: '2.5m',
       address: null,
     },
+    sentinel: {
+      docker: {
+        image: 'dashpay/sentinel:1.5.0',
+      },
+    },
     devnetName: null,
   },
   platform: {


### PR DESCRIPTION
This PR adds the Sentinel image version to config.

## Issue being fixed or feature implemented
Sentinel is the only service not yet included and versioned in config. It should be in config so it can be updated independently to mn-bootstrap updates by users directly using `mn config:set`

## What was done?
Added `core.sentinel.docker.image` setting and upgrade rules.


## How Has This Been Tested?
I was unable to test upgrade rules since I'm still not sure how semver parses `-dev` suffixes, see discussion [here](https://github.com/dashevo/mn-bootstrap/pull/252#discussion_r568102141).

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
