### PR TITLE
feat: enable llmq-qvvec-sync on testnet

### DIFF
--- a/templates/dashd.conf.template
+++ b/templates/dashd.conf.template
@@ -36,6 +36,7 @@ zmqpubrawchainlocksig=tcp://0.0.0.0:29998
 zmqpubrawtxlocksig=tcp://0.0.0.0:29998
 
 {{? it.network === 'testnet'}}testnet=1
+llmq-qvvec-sync=llmq_100_67
 [test]
 {{?? it.network === 'local'}}
 regtest=1


### PR DESCRIPTION
llmq-qvvec-sync is used to synchronise quorum verification vectors

## Issue being fixed or feature implemented
Masternodes not deployed by the deploy tool do not contain this setting

## What was done?
Add `llmq-qvvec-sync=llmq_100_67` to testnet dash.conf


## How Has This Been Tested?
Started testnet node, sync is included in file and core does not crash.


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
