### PR TITLE
fix: reset function doesn't wait for volume to be removed

### DIFF
--- a/src/commands/reset.js
+++ b/src/commands/reset.js
@@ -71,9 +71,11 @@ class ResetCommand extends BaseCommand {
             .filter((volumeName) => !coreVolumeNames.includes(volumeName))
             .map((volumeName) => `${composeProjectName}_${volumeName}`);
 
+          const volumeRemovePromises = [];
           for (const volumeName of volumeNames) {
-            await (docker.getVolume(volumeName)).remove();
+            volumeRemovePromises.push(docker.getVolume(volumeName).remove());
           }
+          await Promise.all(volumeRemovePromises);
         },
       },
       {

--- a/src/commands/reset.js
+++ b/src/commands/reset.js
@@ -67,10 +67,13 @@ class ResetCommand extends BaseCommand {
 
           const projectvolumeNames = await dockerCompose.getVolumeNames(config.toEnvs());
 
-          await projectvolumeNames
+          const volumeNames = projectvolumeNames
             .filter((volumeName) => !coreVolumeNames.includes(volumeName))
-            .map((volumeName) => `${composeProjectName}_${volumeName}`)
-            .forEach(async (volumeName) => docker.getVolume(volumeName).remove());
+            .map((volumeName) => `${composeProjectName}_${volumeName}`);
+
+          for (const volumeName of volumeNames) {
+            await (docker.getVolume(volumeName)).remove();
+          }
         },
       },
       {

--- a/src/commands/reset.js
+++ b/src/commands/reset.js
@@ -67,14 +67,11 @@ class ResetCommand extends BaseCommand {
 
           const projectvolumeNames = await dockerCompose.getVolumeNames(config.toEnvs());
 
-          const volumeNames = projectvolumeNames
+          const volumeRemovePromises = projectvolumeNames
             .filter((volumeName) => !coreVolumeNames.includes(volumeName))
-            .map((volumeName) => `${composeProjectName}_${volumeName}`);
+            .map((volumeName) => `${composeProjectName}_${volumeName}`)
+            .map((volumeName) => docker.getVolume(volumeName).remove());
 
-          const volumeRemovePromises = [];
-          for (const volumeName of volumeNames) {
-            volumeRemovePromises.push(docker.getVolume(volumeName).remove());
-          }
           await Promise.all(volumeRemovePromises);
         },
       },


### PR DESCRIPTION
Change async function to wait for promises to resolve before moving on to sync code.


## Issue being fixed or feature implemented
Tenderdash was crashing after `mn reset --platform-only` because the Tenderdash volume was deleted, but not recreated. This was a sporadic problem, when the system was under load it did not occur.

## What was done?
Investigation showed the async function to get the docker container and remove it wasn't waiting for the promise to resolve before continuing. I think it is [this problem](https://stackoverflow.com/questions/37576685/using-async-await-with-a-foreach-loop). It works now, but I don't know why. It is almost certainly possible to improve this further using `Promise.all` or using proper chaining syntax.


## How Has This Been Tested?
Test multiple times with low system load, cannot reproduce the bug again.

## Breaking Changes

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
