### PR TITLE
fix: platform sync shows Infinity%

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -201,6 +201,33 @@
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.45",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.45.tgz",
+          "integrity": "sha512-703YTEp8AwQeapI0PTXDOj+Bs/mtdV/k9VcTP7z/de+lx6XjFMKdB+JhKnK+6PZ5za7omgZ3V6qm/dNkMj/Zow=="
+        },
+        "protobufjs": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+          "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": "^13.7.0",
+            "long": "^4.0.0"
+          }
+        }
       }
     },
     "@jsdevtools/ono": {

--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -131,7 +131,7 @@ class StatusCommand extends BaseCommand {
     }
 
     const platformExplorerURLs = {
-      testnet: '',
+      testnet: 'https://rpc.cloudwheels.net:26657',
       mainnet: '',
     };
 

--- a/src/commands/status/platform.js
+++ b/src/commands/status/platform.js
@@ -44,7 +44,8 @@ class CoreStatusCommand extends BaseCommand {
     );
 
     const explorerURLs = {
-      testnet: null,
+      testnet: 'https://rpc.cloudwheels.net:26657',
+      mainnet: '',
     };
 
     if (!(await dockerCompose.isServiceRunning(config.toEnvs(), 'drive_tenderdash'))) {
@@ -91,7 +92,7 @@ class CoreStatusCommand extends BaseCommand {
     let explorerLatestBlockHeight;
     if (explorerURLs[config.options.network]) {
       try {
-        const explorerBlockHeightRes = await fetch(explorerURLs[config.options.network]);
+        const explorerBlockHeightRes = await fetch(`${explorerURLs[config.options.network]}/status`);
         ({
           result: {
             sync_info: {


### PR DESCRIPTION
This PR fixes a display error in the `status` and `status:platform` commands now that an external block explorer is available.

## Issue being fixed or feature implemented
The `status` and `status:platform` commands would show `Infinity%` remaining sync when no external source of the final platform block height was available.

## What was done?
Added a URL to an external platform block explorer (thanks cloudwheels for setting this up)


## How Has This Been Tested?
Tested while syncing platform on testnet.

## Breaking Changes
Why did package-lock.json get updated? Does this break anything?


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
