### PR TITLE
fix: grouped configs are not allowed to use

### DIFF
--- a/src/oclif/command/ConfigBaseCommand.js
+++ b/src/oclif/command/ConfigBaseCommand.js
@@ -35,10 +35,6 @@ class GroupBaseCommand extends BaseCommand {
 
     const config = configFile.getConfig(configName);
 
-    if (config.get('group') !== null) {
-      throw new Error(`${config.getName()} config belongs to a group ${config.get('group')}. Please, consider using 'group' commands`);
-    }
-
     this.container.register({
       config: asValue(config),
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Configs included in a group are not allowed to use with non-group commands

## What was done?
<!--- Describe your changes in detail -->
- Removed group assertion for config-required commands

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running commands

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
