### PR TITLE
fix: commands do not work on windows

### DIFF
--- a/src/commands/status/core.js
+++ b/src/commands/status/core.js
@@ -101,12 +101,12 @@ class CoreStatusCommand extends ConfigBaseCommand {
       config.toEnvs(),
       'sentinel',
       'python bin/sentinel.py -v',
-    )).out.split('\n')[0].replace(/Dash Sentinel v/, '');
+    )).out.split(/\r?\n/)[0].replace(/Dash Sentinel v/, '');
     let sentinelState = (await dockerCompose.execCommand(
       config.toEnvs(),
       'sentinel',
       'python bin/sentinel.py',
-    )).out.split('\n')[0];
+    )).out.split(/\r?\n/)[0];
 
     // Determine status
     let status;

--- a/src/commands/status/masternode.js
+++ b/src/commands/status/masternode.js
@@ -70,7 +70,7 @@ class MasternodeStatusCommand extends ConfigBaseCommand {
       config.toEnvs(),
       'sentinel',
       'python bin/sentinel.py',
-    )).out.split('\n')[0];
+    )).out.split(/\r?\n/)[0];
 
     // Determine status
     let status;

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -134,6 +134,7 @@ class Config {
     return {
       COMPOSE_PROJECT_NAME: `dash_masternode_${this.getName()}`,
       CONFIG_NAME: this.getName(),
+      COMPOSE_PATH_SEPARATOR: ':',
       ...convertObjectToEnvs(this.getOptions()),
     };
   }

--- a/src/docker/DockerCompose.js
+++ b/src/docker/DockerCompose.js
@@ -51,7 +51,7 @@ class DockerCompose {
       throw new DockerComposeError(e);
     }
 
-    containerName = containerName.trim().split('\n').pop();
+    containerName = containerName.trim().split(/\r?\n/).pop();
 
     this.startedContainers.addContainer(containerName);
 
@@ -210,7 +210,7 @@ class DockerCompose {
 
     return psOutput
       .trim()
-      .split('\n')
+      .split(/\r?\n/)
       .filter(Boolean);
   }
 
@@ -231,7 +231,7 @@ class DockerCompose {
 
     return volumeOutput
       .trim()
-      .split('\n');
+      .split(/\r?\n/);
   }
 
   /**

--- a/src/oclif/errors/MuteOneLineError.js
+++ b/src/oclif/errors/MuteOneLineError.js
@@ -7,7 +7,7 @@ class MuteOneLineError extends AbstractError {
   constructor(error) {
     super('SIGINT');
 
-    if (error.message && error.message.trimEnd().includes(/\r?\n/)) {
+    if (error.message && error.message.trimEnd().includes('\n')) {
       this.name = error.name;
       this.message = error.message;
       this.stack = error.stack;

--- a/src/oclif/errors/MuteOneLineError.js
+++ b/src/oclif/errors/MuteOneLineError.js
@@ -7,7 +7,7 @@ class MuteOneLineError extends AbstractError {
   constructor(error) {
     super('SIGINT');
 
-    if (error.message && error.message.trimEnd().includes('\n')) {
+    if (error.message && error.message.trimEnd().includes(/\r?\n/)) {
       this.name = error.name;
       this.message = error.message;
       this.stack = error.stack;


### PR DESCRIPTION
This PR allows mn-bootstrap to run on Windows if proper dependencies are installed.

## Issue being fixed or feature implemented
New platform devs may be using Windows instead of unix-based systems and need an easy way to set up a local node for development purposes.

## What was done?
- Specify compose path separator to override default of `;` on windows
- Use regex instead of literal to detect end of line


## How Has This Been Tested?
Tested on Windows 10 and Ubuntu 20.10

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
