### PR TITLE
fix: make services stop in a reverse order to avoid nodes getting banned

### DIFF
--- a/src/commands/group/stop.js
+++ b/src/commands/group/stop.js
@@ -27,7 +27,9 @@ class GroupStopCommand extends GroupBaseCommand {
         {
           title: `Stop ${groupName} nodes`,
           task: () => (
-            new Listr(configGroup.map((config) => ({
+            // So we stop the miner first, as there's a chance that MNs will get banned
+            // if the miner is still running when stopping them
+            new Listr(configGroup.reverse().map((config) => ({
               task: () => stopNodeTask(config),
             })))
           ),

--- a/src/core/waitForCoreQuorum.js
+++ b/src/core/waitForCoreQuorum.js
@@ -15,7 +15,7 @@ async function waitForCoreQuorum(rpcClient) {
 
     if (quorums) {
       for (const quorum of Object.values(quorums)) {
-        if (quorum.length > 0) {
+        if (quorum.length > 1) {
           hasQuorums = true;
         }
       }

--- a/src/listr/tasks/platform/initTaskFactory.js
+++ b/src/listr/tasks/platform/initTaskFactory.js
@@ -62,8 +62,6 @@ function initTaskFactory(
             wallet: {
               mnemonic: null,
             },
-            passFakeAssetLockProofForTests:
-              config.get('platform.drive.passFakeAssetLockProofForTests', true),
           });
 
           const amount = 40000;

--- a/src/listr/tasks/setup/local/initializePlatformTaskFactory.js
+++ b/src/listr/tasks/setup/local/initializePlatformTaskFactory.js
@@ -73,7 +73,9 @@ function initializePlatformTaskFactory(
       {
         title: 'Stopping nodes',
         task: async () => {
-          const stopNodeTasks = configGroup.map((config) => ({
+          // So we stop the miner first, as there's a chance that MNs will get banned
+          // if the miner is still running when stopping them
+          const stopNodeTasks = configGroup.reverse().map((config) => ({
             title: `Stop ${config.getName()} node`,
             task: () => dockerCompose.stop(config.toEnvs()),
           }));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make mn-bootstrap to work without fake AS proofs

## What was done?
<!--- Describe your changes in detail -->
- removed `passFakeAssetLock` option 
- make services stop in reverse order to avoid mns getting banned
- increased quorums waiting to 2 quorums from 1

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
