### PR TITLE
fix: waitForNodeToBeReady tasks were constructed in a wrong way

### DIFF
--- a/src/commands/group/start.js
+++ b/src/commands/group/start.js
@@ -54,12 +54,14 @@ class GroupStartCommand extends GroupBaseCommand {
         {
           title: 'Await for nodes to be ready',
           enabled: waitForReadiness,
-          task: async () => {
-            await Promise.all(
-              configGroup
-                .filter((config) => config.isPlatformServicesEnabled())
-                .map(waitForNodeToBeReadyTask),
-            );
+          task: () => {
+            const waitForNodeToBeReadyTasks = configGroup
+              .filter((config) => config.isPlatformServicesEnabled())
+              .map((config) => ({
+                task: () => waitForNodeToBeReadyTask(config),
+              }));
+
+            return new Listr(waitForNodeToBeReadyTasks);
           },
         },
       ],

--- a/src/listr/tasks/setup/local/initializePlatformTaskFactory.js
+++ b/src/listr/tasks/setup/local/initializePlatformTaskFactory.js
@@ -50,12 +50,14 @@ function initializePlatformTaskFactory(
       },
       {
         title: 'Await for nodes to be ready',
-        task: async () => {
-          await Promise.all(
-            configGroup
-              .filter((config) => config.isPlatformServicesEnabled())
-              .map(waitForNodeToBeReadyTask),
-          );
+        task: () => {
+          const waitForNodeToBeReadyTasks = configGroup
+            .filter((config) => config.isPlatformServicesEnabled())
+            .map((config) => ({
+              task: () => waitForNodeToBeReadyTask(config),
+            }));
+
+          return new Listr(waitForNodeToBeReadyTasks);
         },
       },
       {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`waitForNodeToBeReady` tasks were constructed in a wrong way

## What was done?
<!--- Describe your changes in detail -->
- Fixed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local setup

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
