### PR TITLE
fix: cannot register testnet mn

### DIFF
--- a/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
@@ -113,12 +113,12 @@ function setupRegularPresetTaskFactory(
         options: { persistentOutput: true },
       },
       {
-        title: 'Register masternode',
+        title: 'Prepare keys',
         enabled: (ctx) => (
           ctx.nodeType === NODE_TYPE_MASTERNODE
           && ctx.fundingPrivateKeyString !== undefined
         ),
-        task: async (ctx) => {
+        task: (ctx) => {
           if (ctx.preset === PRESET_MAINNET) {
             throw new Error('For your own security, this tool will not process mainnet private keys. You should consider the private key you entered to be compromised.');
           }
@@ -129,9 +129,16 @@ function setupRegularPresetTaskFactory(
           // Write configs
           const configFiles = renderServiceTemplates(ctx.config);
           writeServiceConfigs(ctx.config.getName(), configFiles);
-
-          await registerMasternodeTask(ctx.config);
         },
+        options: { persistentOutput: true },
+      },
+      {
+        title: 'Register masternode',
+        enabled: (ctx) => (
+          ctx.nodeType === NODE_TYPE_MASTERNODE
+          && ctx.fundingPrivateKeyString !== undefined
+        ),
+        task: (ctx) => registerMasternodeTask(ctx.config),
         options: { persistentOutput: true },
       },
       {

--- a/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
@@ -113,7 +113,7 @@ function setupRegularPresetTaskFactory(
         options: { persistentOutput: true },
       },
       {
-        title: 'Prepare keys',
+        title: 'Register masternode',
         enabled: (ctx) => (
           ctx.nodeType === NODE_TYPE_MASTERNODE
           && ctx.fundingPrivateKeyString !== undefined

--- a/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
@@ -135,15 +135,6 @@ function setupRegularPresetTaskFactory(
         options: { persistentOutput: true },
       },
       {
-        title: 'Register masternode',
-        enabled: (ctx) => (
-          ctx.nodeType === NODE_TYPE_MASTERNODE
-          && ctx.fundingPrivateKeyString !== undefined
-        ),
-        task: (ctx) => registerMasternodeTask(ctx.config),
-        options: { persistentOutput: true },
-      },
-      {
         title: 'Initialize Tenderdash',
         task: (ctx) => tenderdashInitTask(ctx.config),
       },

--- a/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
@@ -129,6 +129,8 @@ function setupRegularPresetTaskFactory(
           // Write configs
           const configFiles = renderServiceTemplates(ctx.config);
           writeServiceConfigs(ctx.config.getName(), configFiles);
+
+          return registerMasternodeTask(ctx.config);
         },
         options: { persistentOutput: true },
       },


### PR DESCRIPTION
This PR fixes a bug when registering a testnet masternode with a provided collateral private key.

## Issue being fixed or feature implemented
`mn setup testnet masternode -p <privkey>` was failing with the "Register masternode" step not executing.


## What was done?
Return the listr object instead of waiting for it to complete. I'm not sure why this worked during development, and also not sure why this fixes it...


## How Has This Been Tested?
Tested on testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
