### PR TITLE
fix: mn-bootstrap not working with docker-compose 1.29

### DIFF
--- a/src/docker/DockerCompose.js
+++ b/src/docker/DockerCompose.js
@@ -73,7 +73,15 @@ class DockerCompose {
     for (const containerId of coreContainerIds) {
       const container = this.docker.getContainer(containerId);
 
-      const { State: { Status: status } } = await container.inspect();
+      let status;
+
+      try {
+        ({ State: { Status: status } } = await container.inspect());
+      } catch (e) {
+        if (!e.message.includes(`No such container: ${containerId}`)) {
+          throw e;
+        }
+      }
 
       if (status === 'running') {
         return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With docker-compose 1.29 container.inspect throws error if the container isn't running

## What was done?
<!--- Describe your changes in detail -->
Catch error thrown by `container.expect()` and if it's "no such container" error, return false, as container isn't running

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
