### PR TITLE
fix: wait for masternodes to be synced before start miner

### DIFF
--- a/src/core/waitForMasternodesSync.js
+++ b/src/core/waitForMasternodesSync.js
@@ -1,0 +1,32 @@
+const wait = require('../util/wait');
+
+/**
+ * Wait Core to be synced
+ *
+ * @typedef {waitForCoreSync}
+ * @param {RpcClient} rpcClient
+ * @param {function(progress: number)} [progressCallback]
+ * @return {Promise<void>}
+ */
+async function waitForMasternodesSync(rpcClient, progressCallback = () => {}) {
+  let isSynced = false;
+  let verificationProgress = 0.0;
+
+  do {
+    await rpcClient.mnsync('next');
+
+    ({
+      result: { IsSynced: isSynced },
+    } = await rpcClient.mnsync('status'));
+    ({
+      result: { verificationprogress: verificationProgress },
+    } = await rpcClient.getBlockchainInfo());
+
+    if (!isSynced) {
+      await wait(10000);
+      progressCallback(verificationProgress);
+    }
+  } while (!isSynced);
+}
+
+module.exports = waitForMasternodesSync;

--- a/src/createDIContainer.js
+++ b/src/createDIContainer.js
@@ -31,6 +31,7 @@ const startCoreFactory = require('./core/startCoreFactory');
 const createRpcClient = require('./core/createRpcClient');
 const waitForCoreStart = require('./core/waitForCoreStart');
 const waitForCoreSync = require('./core/waitForCoreSync');
+const waitForMasternodesSync = require('./core/waitForMasternodesSync');
 const waitForBlocks = require('./core/waitForBlocks');
 const waitForConfirmations = require('./core/waitForConfirmations');
 const generateBlsKeys = require('./core/generateBlsKeys');
@@ -119,6 +120,7 @@ async function createDIContainer(options) {
     createRpcClient: asValue(createRpcClient),
     waitForCoreStart: asValue(waitForCoreStart),
     waitForCoreSync: asValue(waitForCoreSync),
+    waitForMasternodesSync: asValue(waitForMasternodesSync),
     startCore: asFunction(startCoreFactory).singleton(),
     waitForBlocks: asValue(waitForBlocks),
     waitForConfirmations: asValue(waitForConfirmations),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If miner starts working before all masternodes are synched, a masternode could be banned.

## What was done?
<!--- Describe your changes in detail -->
New task to wait for masternodes to be synced before starting miner

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
