### PR TITLE
fix: error running status command on seed node

### DIFF
--- a/src/status/outputStatusOverviewFactory.js
+++ b/src/status/outputStatusOverviewFactory.js
@@ -90,7 +90,7 @@ function outputStatusOverviewFactory(
     let platformCatchingUp;
     let platformStatus;
 
-    if (config.options.network !== 'mainnet') {
+    if (config.options.network !== 'mainnet' && config.name !== 'local_seed') {
       if (!(await dockerCompose.isServiceRunning(config.toEnvs(), 'drive_tenderdash'))) {
         try {
           ({
@@ -211,7 +211,7 @@ function outputStatusOverviewFactory(
       coreStatus = chalk.red(coreStatus);
     }
 
-    if (config.options.network !== 'mainnet') {
+    if (config.options.network !== 'mainnet' && config.name !== 'local_seed') {
       if (platformStatus === 'running') {
         platformStatus = chalk.green(platformStatus);
       } else if (platformStatus.startsWith('syncing')) {
@@ -235,7 +235,7 @@ function outputStatusOverviewFactory(
       rows.push(['Masternode Status', (masternodeStatus)]);
     }
 
-    if (config.options.network !== 'mainnet') {
+    if (config.options.network !== 'mainnet' && config.name !== 'local_seed') {
       if (coreIsSynced === true
         && platformStatus !== chalk.red('not started')
         && platformStatus !== chalk.red('restarting')) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#359 
`dashmate group:status` returns `DockerComposeError: Docker Compose error: No such service: drive_tenderdash` when running against a local network. This is because the local seed node does not run platform chain.


## What was done?
<!--- Describe your changes in detail -->
Add condition checks to the group status command so they do not run against the seed node.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
