### PR TITLE
fix: unavailable log settings on seed node

### DIFF
--- a/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -103,12 +103,9 @@ function setupLocalPresetTaskFactory(
                 config.set('core.rpc.port', 20002 + (i * 100));
                 config.set('externalIp', hostDockerInternalIp);
 
+                // Setup Core debug logs
                 if (ctx.debugLogs) {
                   config.set('core.debug', 1);
-                  config.set('platform.drive.abci.log.stdout.level', 'trace');
-                  config.set('platform.drive.tenderdash.log.level', {
-                    '*': 'debug',
-                  });
                 }
 
                 // Although not all nodes are miners, all nodes should be aware of
@@ -133,6 +130,14 @@ function setupLocalPresetTaskFactory(
                   config.set('platform.dapi.envoy.grpc.port', 3010 + (i * 100));
                   config.set('platform.drive.tenderdash.p2p.port', 26656 + (i * 100));
                   config.set('platform.drive.tenderdash.rpc.port', 26657 + (i * 100));
+
+                  // Setup logs
+                  if (ctx.debugLogs) {
+                    config.set('platform.drive.abci.log.stdout.level', 'trace');
+                    config.set('platform.drive.tenderdash.log.level', {
+                      '*': 'debug',
+                    });
+                  }
 
                   config.set('platform.drive.abci.log.prettyFile.path', path.join(os.tmpdir(), `/drive_pretty_${nodeIndex}.log`));
                   config.set('platform.drive.abci.log.jsonFile.path', path.join(os.tmpdir(), `/drive_json_${nodeIndex}.log`));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`setup local --debug-logs` command throws multiple errors due to seed node doesn't contain platform settings.

## What was done?
<!--- Describe your changes in detail -->
- Set drive log settings only on platform nodes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running `setup local --debug-logs`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
