### PR TITLE
fix: Dash JSON-RPC: Request Error: socket hang up

### DIFF
--- a/src/core/waitForMasternodesSync.js
+++ b/src/core/waitForMasternodesSync.js
@@ -16,9 +16,12 @@ async function waitForMasternodesSync(rpcClient, progressCallback = () => {}) {
     try {
       await rpcClient.mnsync('next');
     } catch (e) {
-      if (!['ECONNABORTED', 'ECONNREFUSED', 'ETIMEDOUT', -28].includes(e.code)) {
+      // Core RPC is not started yet
+      if (!e.message.includes('Dash JSON-RPC: Request Error: ') && e.code !== -28) {
         throw e;
       }
+
+      progressCallback(verificationProgress);
 
       // Wait for Core RPC is started
       await wait(50);

--- a/src/core/waitForMasternodesSync.js
+++ b/src/core/waitForMasternodesSync.js
@@ -15,8 +15,8 @@ async function waitForMasternodesSync(rpcClient, progressCallback = () => {}) {
   do {
     try {
       await rpcClient.mnsync('next');
-    } catch(e) {
-      if (e.code !== -28) {
+    } catch (e) {
+      if (!['ECONNABORTED', 'ECONNREFUSED', 'ETIMEDOUT', -28].includes(e.code)) {
         throw e;
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
[SUCCESS] Start services [3s]
[STARTED] Force nodes to sync

node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^
OperationalError: Dash JSON-RPC: Request Error: socket hang up
    at ClientRequest.<anonymous> (/tmp/dashmate/node_modules/@dashevo/dashd-rpc/lib/index.js:138:17)
    at ClientRequest.emit (node:events:390:28)
    at Socket.socketOnEnd (node:_http_client:471:9)
    at Socket.emit (node:events:402:35)
    at endReadableNT (node:internal/streams/readable:1343:12)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
```

## What was done?
<!--- Describe your changes in detail -->
- Retry masternode sync if Core RPC is not started and we getting HTTP connection errors 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Asked Leon 😜

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
