### PR TITLE
fix: wallet access on seed node in local test network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,11 @@ services:
     volumes:
       - core_data:/dash
       - ${DASHMATE_HOME_DIR:?err}/${CONFIG_NAME:?err}/core/dash.conf:/dash/.dashcore/dash.conf
-    command:
-      - dashd
-      - -masternodeblsprivkey=${CORE_MASTERNODE_OPERATOR_PRIVATE_KEY}
+    command: bash -c "if [[ $CORE_MASTERNODE_ENABLE = true ]]; then
+                   dashd -masternodeblsprivkey=${CORE_MASTERNODE_OPERATOR_PRIVATE_KEY};
+                else
+                   dashd;
+                fi"
 
 volumes:
   core_data:


### PR DESCRIPTION
Wallet access on seed node (via rpcs) in local network now works. Changed the docker-compose file so it does not feed the `-masternodeblsprivkey` flag to `dashd` when a node is not a masternode. As a result wallet functionality is not disabled in seed node, which it previously was.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Fixes issue [https://github.com/dashevo/dashmate/issues/465](url). 


## What was done?
Change docker-compose command for core containers. Use bash to first check whether node is a masternode, if not a masternode then do not add the `-masternodeblsprivkey`flag to the dashd command.


## How Has This Been Tested?
Used `dashmate setup local`, to set up local network. Then use RPC to check whether wallet functionality on seed node works, which it does. Starting and stopping of nodes works fine.

No known effects on other code.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
